### PR TITLE
Update CLAWDBOT_GIT_REF to v2026.1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN corepack enable
 WORKDIR /clawdbot
 
 # Pin to a known ref (tag/branch). If it doesn't exist, fall back to main.
-ARG CLAWDBOT_GIT_REF=main
+ARG CLAWDBOT_GIT_REF=v2026.1.22
 RUN git clone --depth 1 --branch "${CLAWDBOT_GIT_REF}" https://github.com/clawdbot/clawdbot.git .
 
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
Fix build error by using stable Clawdbot release v2026.1.22 instead of main branch.

The main branch has a TypeScript compilation error in src/agents/venice-models.ts that was causing the Railway build to fail. Using the stable tagged release resolves this issue.