### PR TITLE
Fix Dockerfile build failure: handle pnpm workspace protocol in extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,11 @@ ARG CLAWDBOT_GIT_REF=main
 RUN git clone --depth 1 --branch "${CLAWDBOT_GIT_REF}" https://github.com/clawdbot/clawdbot.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.
-# Scope this narrowly to avoid surprising dependency mutations.
+# Apply to all extension package.json files to handle workspace protocol (workspace:*).
 RUN set -eux; \
-  for f in \
-    ./extensions/memory-core/package.json \
-    ./extensions/googlechat/package.json \
-  ; do \
-    if [ -f "$f" ]; then \
-      sed -i -E 's/"clawdbot"[[:space:]]*:[[:space:]]*">=[^"]+"/"clawdbot": "*"/g' "$f"; \
-    fi; \
+  find ./extensions -name 'package.json' -type f | while read -r f; do \
+    sed -i -E 's/"clawdbot"[[:space:]]*:[[:space:]]*">=[^"]+"/"clawdbot": "*"/g' "$f"; \
+    sed -i -E 's/"clawdbot"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"clawdbot": "*"/g' "$f"; \
   done
 
 RUN pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary
- Apply dependency version patch to all extensions (not just hardcoded list)
- Handle pnpm `workspace:*` protocol in addition to semver ranges

## Problem
Build fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` because extensions now use `"clawdbot": "workspace:*"` instead of semver ranges.

## Solution
Use `find` to patch all extension package.json files and add sed pattern for workspace protocol.
```