### PR TITLE
Fix memory exhaustion and add system requirements docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,4 @@ COPY src ./src
 
 ENV PORT=8080
 EXPOSE 8080
-CMD ["node", "src/server.js"]
+CMD ["node", "--max-old-space-size=2048", "src/server.js"]


### PR DESCRIPTION
## Summary
- Adds `--max-old-space-size=2048` Node.js flag to prevent OOM crashes on Railway
- Documents 1GB minimum RAM requirement in new System Requirements section
- Adds troubleshooting guide for common deployment issues

Fixes #19

## Problem
Railway deployments crash after ~38 seconds with "JavaScript heap out of memory" error. The free tier (512MB) is insufficient for wrapper + gateway processes.

## Solution
- Node.js heap limit increased to 2GB via Dockerfile CMD flag
- Clear documentation that Hobby plan ($5/month, 1GB RAM) is minimum requirement
- Comprehensive troubleshooting section for OOM and other common issues

## Test Plan
- [x] Docker build succeeds
- [x] Verify CMD includes `--max-old-space-size=2048` flag
- [x] Deploy to Railway Hobby plan and verify no crashes
- [ ] Monitor memory usage stays under 1.5GB during normal operation

## Confirmation of it working

<img width="1400" height="1061" alt="Screenshot 2026-01-27 at 11 30 18 AM" src="https://github.com/user-attachments/assets/bee486d3-0f19-4d33-af57-8f465f3dcb00" />

<img width="868" height="1061" alt="Screenshot 2026-01-27 at 11 29 44 AM" src="https://github.com/user-attachments/assets/8f7f5d19-64ed-4c8c-a8cd-34818f550e0f" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)