### PR TITLE
fix: force wrapper to listen on 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ RUN printf '%s\n' '#!/usr/bin/env bash' 'exec node /clawdbot/dist/entry.js "$@"'
 
 COPY src ./src
 
+# The wrapper listens on this port.
+ENV CLAWDBOT_PUBLIC_PORT=8080
 ENV PORT=8080
 EXPOSE 8080
 CMD ["node", "src/server.js"]

--- a/src/server.js
+++ b/src/server.js
@@ -8,8 +8,11 @@ import express from "express";
 import httpProxy from "http-proxy";
 import * as tar from "tar";
 
-// Railway commonly sets PORT=8080 for HTTP services.
-const PORT = Number.parseInt(process.env.PORT ?? "8080", 10);
+// Railway deployments sometimes inject PORT=3000 by default. We want the wrapper to
+// reliably listen on 8080 unless explicitly overridden.
+//
+// Prefer CLAWDBOT_PUBLIC_PORT (set in the Dockerfile / template) over PORT.
+const PORT = Number.parseInt(process.env.CLAWDBOT_PUBLIC_PORT ?? process.env.PORT ?? "8080", 10);
 const STATE_DIR = process.env.CLAWDBOT_STATE_DIR?.trim() || path.join(os.homedir(), ".clawdbot");
 const WORKSPACE_DIR = process.env.CLAWDBOT_WORKSPACE_DIR?.trim() || path.join(STATE_DIR, "workspace");
 


### PR DESCRIPTION
Railway is showing the wrapper listening on :3000. Make the wrapper prefer CLAWDBOT_PUBLIC_PORT (set to 8080 in the Dockerfile) over PORT so it reliably binds 8080 even if Railway injects PORT=3000 by default.

Users can still override by setting CLAWDBOT_PUBLIC_PORT.