### PR TITLE
Remove deprecated codex-cli auth option

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -298,7 +298,6 @@ app.get("/setup/api/status", requireSetupAuth, async (_req, res) => {
   // This is intentionally minimal; later we can parse the CLI help output to stay perfectly in sync.
   const authGroups = [
     { value: "openai", label: "OpenAI", hint: "Codex OAuth + API key", options: [
-      { value: "codex-cli", label: "OpenAI Codex OAuth (Codex CLI)" },
       { value: "openai-codex", label: "OpenAI Codex (ChatGPT OAuth)" },
       { value: "openai-api-key", label: "OpenAI API key" }
     ]},


### PR DESCRIPTION
## Summary
- Removes deprecated `codex-cli` authentication option from setup wizard

## Problem
When users select the OpenAI authentication group in the setup wizard, they see the deprecated "OpenAI Codex OAuth (Codex CLI)" option which causes this warning:

```
Auth choice "codex-cli" is deprecated.
Use "--auth-choice token" (Anthropic setup-token) or "--auth-choice openai-codex".
```

## Solution
Remove the deprecated option from the auth groups list. Users should use:
- `openai-codex` (OpenAI Codex with ChatGPT OAuth)
- `openai-api-key` (OpenAI API key)

## Changes
- Remove `codex-cli` from OpenAI auth options in `src/server.js:301`

🤖 Generated with [Claude Code](https://claude.com/claude-code)