### PR TITLE
fix: remove deprecated claude-cli auth choice

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -306,8 +306,7 @@ app.get("/setup/api/status", requireSetupAuth, async (_req, res) => {
       { value: "openai-api-key", label: "OpenAI API key" }
     ]},
     { value: "anthropic", label: "Anthropic", hint: "Claude Code CLI + API key", options: [
-      { value: "claude-cli", label: "Anthropic token (Claude Code CLI)" },
-      { value: "token", label: "Anthropic token (paste setup-token)" },
+      { value: "token", label: "Anthropic token (setup-token)" },
       { value: "apiKey", label: "Anthropic API key" }
     ]},
     { value: "google", label: "Google", hint: "Gemini API key + OAuth", options: [


### PR DESCRIPTION
Removes the deprecated "claude-cli" auth option that was causing warnings. The --auth-choice "claude-cli" is deprecated in favor of "--auth-choice token" (Anthropic setup-token) or "--auth-choice openai-codex".

This change:
- Removes the deprecated "claude-cli" option from the Anthropic auth group
- Simplifies the label for the "token" option to be clearer
- Maintains support for both "token" and "apiKey" auth methods