### PR TITLE
Migrate template to OpenClaw (rename + new defaults)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
-          tags: clawdbot-railway-template:ci
+          tags: openclaw-railway-template:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# Build clawdbot from source to avoid npm packaging gaps (some dist files are not shipped).
-FROM node:22-bookworm AS clawdbot-build
+# Build openclaw from source to avoid npm packaging gaps (some dist files are not shipped).
+FROM node:22-bookworm AS openclaw-build
 
-# Dependencies needed for clawdbot build
+# Dependencies needed for openclaw build
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     git \
@@ -12,29 +12,29 @@ RUN apt-get update \
     g++ \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Bun (clawdbot build uses it)
+# Install Bun (openclaw build uses it)
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
 RUN corepack enable
 
-WORKDIR /clawdbot
+WORKDIR /openclaw
 
 # Pin to a known ref (tag/branch). If it doesn't exist, fall back to main.
-ARG CLAWDBOT_GIT_REF=main
-RUN git clone --depth 1 --branch "${CLAWDBOT_GIT_REF}" https://github.com/clawdbot/clawdbot.git .
+ARG OPENCLAW_GIT_REF=main
+RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.
 # Apply to all extension package.json files to handle workspace protocol (workspace:*).
 RUN set -eux; \
   find ./extensions -name 'package.json' -type f | while read -r f; do \
-    sed -i -E 's/"clawdbot"[[:space:]]*:[[:space:]]*">=[^"]+"/"clawdbot": "*"/g' "$f"; \
-    sed -i -E 's/"clawdbot"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"clawdbot": "*"/g' "$f"; \
+    sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*">=[^"]+"/"openclaw": "*"/g' "$f"; \
+    sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
 RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
-ENV CLAWDBOT_PREFER_PNPM=1
+ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:install && pnpm ui:build
 
 
@@ -53,17 +53,17 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=dev && npm cache clean --force
 
-# Copy built clawdbot
-COPY --from=clawdbot-build /clawdbot /clawdbot
+# Copy built openclaw
+COPY --from=openclaw-build /openclaw /openclaw
 
-# Provide a clawdbot executable
-RUN printf '%s\n' '#!/usr/bin/env bash' 'exec node /clawdbot/dist/entry.js "$@"' > /usr/local/bin/clawdbot \
-  && chmod +x /usr/local/bin/clawdbot
+# Provide an openclaw executable
+RUN printf '%s\n' '#!/usr/bin/env bash' 'exec node /openclaw/dist/entry.js "$@"' > /usr/local/bin/openclaw \
+  && chmod +x /usr/local/bin/openclaw
 
 COPY src ./src
 
 # The wrapper listens on this port.
-ENV CLAWDBOT_PUBLIC_PORT=8080
+ENV OPENCLAW_PUBLIC_PORT=8080
 ENV PORT=8080
 EXPOSE 8080
 CMD ["node", "src/server.js"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Clawdbot Railway Template (1‑click deploy)
+# OpenClaw Railway Template (1‑click deploy)
 
-This repo packages **Clawdbot** for Railway with a small **/setup** web wizard so users can deploy and onboard **without running any commands**.
+This repo packages **OpenClaw** for Railway with a small **/setup** web wizard so users can deploy and onboard **without running any commands**.
 
 ## What you get
 
-- **Clawdbot Gateway + Control UI** (served at `/` and `/clawdbot`)
+- **OpenClaw Gateway + Control UI** (served at `/` and `/openclaw`)
 - A friendly **Setup Wizard** at `/setup` (protected by a password)
 - Persistent state via **Railway Volume** (so config/credentials/memory survive redeploys)
 - One-click **Export backup** (so users can migrate off Railway later)
@@ -13,8 +13,8 @@ This repo packages **Clawdbot** for Railway with a small **/setup** web wizard s
 
 - The container runs a wrapper web server.
 - The wrapper protects `/setup` with `SETUP_PASSWORD`.
-- During setup, the wrapper runs `clawdbot onboard --non-interactive ...` inside the container, writes state to the volume, and then starts the gateway.
-- After setup, **`/` is Clawdbot**. The wrapper reverse-proxies all traffic (including WebSockets) to the local gateway process.
+- During setup, the wrapper runs `openclaw onboard --non-interactive ...` inside the container, writes state to the volume, and then starts the gateway.
+- After setup, **`/` is OpenClaw**. The wrapper reverse-proxies all traffic (including WebSockets) to the local gateway process.
 
 ## Railway deploy instructions (what you’ll publish as a Template)
 
@@ -28,14 +28,14 @@ Required:
 - `SETUP_PASSWORD` — user-provided password to access `/setup`
 
 Recommended:
-- `CLAWDBOT_STATE_DIR=/data/.clawdbot`
-- `CLAWDBOT_WORKSPACE_DIR=/data/workspace`
+- `OPENCLAW_STATE_DIR=/data/.openclaw`
+- `OPENCLAW_WORKSPACE_DIR=/data/workspace`
 
 Optional:
-- `CLAWDBOT_GATEWAY_TOKEN` — if not set, the wrapper generates one (not ideal). In a template, set it using a generated secret.
+- `OPENCLAW_GATEWAY_TOKEN` — if not set, the wrapper generates one (not ideal). In a template, set it using a generated secret.
 
 Notes:
-- This template pins Clawdbot to a known-good version by default via Docker build arg `CLAWDBOT_VERSION`.
+- This template pins OpenClaw to a known-good version by default via Docker build arg `OPENCLAW_GIT_REF`.
 
 4) Enable **Public Networking** (HTTP). Railway will assign a domain.
 5) Deploy.
@@ -43,7 +43,7 @@ Notes:
 Then:
 - Visit `https://<your-app>.up.railway.app/setup`
 - Complete setup
-- Visit `https://<your-app>.up.railway.app/` and `/clawdbot`
+- Visit `https://<your-app>.up.railway.app/` and `/openclaw`
 
 ## Getting chat tokens (so you don’t have to scramble)
 
@@ -63,15 +63,15 @@ Then:
 ## Local smoke test
 
 ```bash
-docker build -t clawdbot-railway-template .
+docker build -t openclaw-railway-template .
 
 docker run --rm -p 8080:8080 \
   -e PORT=8080 \
   -e SETUP_PASSWORD=test \
-  -e CLAWDBOT_STATE_DIR=/data/.clawdbot \
-  -e CLAWDBOT_WORKSPACE_DIR=/data/workspace \
+  -e OPENCLAW_STATE_DIR=/data/.openclaw \
+  -e OPENCLAW_WORKSPACE_DIR=/data/workspace \
   -v $(pwd)/.tmpdata:/data \
-  clawdbot-railway-template
+  openclaw-railway-template
 
 # open http://localhost:8080/setup (password: test)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "clawdbot-railway-template",
+  "name": "openclaw-railway-template",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clawdbot-railway-template",
+      "name": "openclaw-railway-template",
       "dependencies": {
         "express": "^5.1.0",
         "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "clawdbot-railway-template",
+  "name": "openclaw-railway-template",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/smoke.js
+++ b/scripts/smoke.js
@@ -1,9 +1,9 @@
 import { spawnSync } from "node:child_process";
 
 // Basic sanity: ensure the wrapper starts and the CLI exists.
-const r = spawnSync("clawdbot", ["--version"], { encoding: "utf8" });
+const r = spawnSync("openclaw", ["--version"], { encoding: "utf8" });
 if (r.status !== 0) {
   console.error(r.stdout || r.stderr);
   process.exit(r.status ?? 1);
 }
-console.log("clawdbot ok:", r.stdout.trim());
+console.log("openclaw ok:", r.stdout.trim());

--- a/src/setup-app.js
+++ b/src/setup-app.js
@@ -56,12 +56,12 @@
   function refreshStatus() {
     setStatus('Loading...');
     return httpJson('/setup/api/status').then(function (j) {
-      var ver = j.clawdbotVersion ? (' | ' + j.clawdbotVersion) : '';
-      setStatus((j.configured ? 'Configured - open /clawdbot' : 'Not configured - run setup below') + ver);
+      var ver = j.openclawVersion ? (' | ' + j.openclawVersion) : '';
+      setStatus((j.configured ? 'Configured - open /openclaw' : 'Not configured - run setup below') + ver);
       renderAuth(j.authGroups || []);
       // If channels are unsupported, surface it for debugging.
       if (j.channelsAddHelp && j.channelsAddHelp.indexOf('telegram') === -1) {
-        logEl.textContent += '\nNote: this clawdbot build does not list telegram in `channels add --help`. Telegram auto-add will be skipped.\n';
+        logEl.textContent += '\nNote: this openclaw build does not list telegram in `channels add --help`. Telegram auto-add will be skipped.\n';
       }
 
     }).catch(function (e) {


### PR DESCRIPTION
## Summary
Updates this Railway template to deploy **OpenClaw** (openclaw/openclaw) instead of the legacy Clawdbot repo/name.

Also adds an initial **Debug Console** in `/setup` (Option A) with an allowlist of safe actions + an advanced raw config editor.

## Key changes
- Docker build now clones/builds `openclaw/openclaw` (arg: `OPENCLAW_GIT_REF`)
- Runtime wrapper calls `openclaw` and defaults to `~/.openclaw` + `openclaw.json`
- UI routes updated to OpenClaw defaults (`/openclaw`)
- Template env vars renamed to `OPENCLAW_*` (with backward-compat support for existing `CLAWDBOT_*` env vars)

## Setup UI improvements (Debug Console + Config Editor)
Inside `/setup` (password-protected):
- **Debug console** (no shell):
  - `gateway.restart|stop|start` (wrapper-managed)
  - `openclaw status|health|doctor|--version`
  - `openclaw logs --tail N`
  - `openclaw config get <path>`
- **Raw config editor** (advanced):
  - GET/POST the full config file (`openclaw.json` by default)
  - Writes a timestamped `.bak-*` backup on save
  - Restarts the gateway after save

## Railway / deploy notes
- Wrapper still prefers an explicit public port env var and guards against Railway's default `PORT` behavior
- Healthcheck remains `/setup/healthz`
- Strongly recommend mounting a Railway Volume at `/data` and setting:
  - `OPENCLAW_STATE_DIR=/data/.openclaw`
  - `OPENCLAW_WORKSPACE_DIR=/data/workspace`

## How to test
- `npm install`
- `npm run lint`
- (In Railway) deploy with a Volume at `/data`, set `SETUP_PASSWORD`, visit `/setup`, run setup, then open `/openclaw`
- Try Debug Console actions (restart, status, logs)
- Edit config (e.g. `gateway.controlUi.basePath`) and save; confirm restart + new route works
