### PR TITLE
Setup UI: debug console + config editor + backup import

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo packages **OpenClaw** for Railway with a small **/setup** web wizard s
 - A friendly **Setup Wizard** at `/setup` (protected by a password)
 - Persistent state via **Railway Volume** (so config/credentials/memory survive redeploys)
 - One-click **Export backup** (so users can migrate off Railway later)
+- **Import backup** from `/setup` (advanced recovery)
 
 ## How it works (high level)
 


### PR DESCRIPTION
## Summary
Adds Option A (safe command runner) and setup UI improvements for Railway deployments.

Also updates the README with an "Official template / endorsements" section and includes the Railway deploy-count screenshot.

## Changes
- `/setup` now includes a **Debug Console** (no shell; allowlisted actions):
  - wrapper-managed: `gateway.start|stop|restart`
  - CLI: `openclaw status|health|doctor|--version`, `openclaw logs --tail N`, `openclaw config get <path>`
- `/setup` now includes an **advanced raw config editor** for the on-disk config (`openclaw.json` by default):
  - reload + save
  - on save: writes a timestamped `.bak-*` backup and restarts gateway
- Adds **Import backup** support:
  - POST `/setup/import` with a `.tar.gz` created by `/setup/export`
  - extraction is limited to `/data` (Railway volume) + basic path traversal guards
  - stops gateway before restore, restarts after
- README: add "Official template / endorsements" + deploy-count screenshot (assets/railway-deploys.jpg)

## Notes / TODO
X (Twitter) blocks automated fetching in our environment, so the README includes TODO placeholders for the two endorsement tweet screenshots. If you upload those images to the repo, I can wire them in and remove the TODO text.

## Security / guardrails
- No interactive terminal / no arbitrary command execution
- Import is only allowed when both `OPENCLAW_STATE_DIR` and `OPENCLAW_WORKSPACE_DIR` are under `/data`
- Tar extraction filters unsafe paths (`..`, absolute paths, drive letters)

## How to test
- Deploy on Railway with a Volume mounted at `/data`
- Set: `OPENCLAW_STATE_DIR=/data/.openclaw`, `OPENCLAW_WORKSPACE_DIR=/data/workspace`, `SETUP_PASSWORD=...`
- Visit `/setup`:
  - run `gateway.restart`
  - run `openclaw status` and `openclaw logs --tail 200`
  - edit config and save (verify restart)
  - export backup, then import it back and confirm restart
