### PR TITLE
Persist configs and installed apps

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "mcp__railway-mcp-server__list-deployments",
-      "Bash(railway up:*)"
+      "Bash(railway up:*)",
+      "Bash(railway ssh --project=b59339fd-ce0f-43fd-9f8d-bec4d6bd4130 --environment=43185058-5248-4be9-bbfd-fe4e5489725d --service=9f836d0c-4f2f-4bb0-8c91-74dd1b642d7b -- \"echo ''=== All dotfiles in HOME ===''; ls -la /root/ 2>/dev/null; echo; echo ''=== ~/clawd? ===''; ls -la /root/clawd 2>/dev/null; echo; echo ''=== ~/.moltbot? ===''; ls -la /root/.moltbot 2>/dev/null; echo; echo ''=== ~/.clawdbot? ===''; ls -la /root/.clawdbot 2>/dev/null; echo; echo ''=== grep for hardcoded paths in openclaw ===''; grep -r ''\\\\.clawdbot\\\\|\\\\.moltbot\\\\|\\\\.openclaw\\\\|/clawd'' /openclaw/dist/entry.js 2>/dev/null | head -20\")"
     ]
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,15 @@ COPY src ./src
 ENV OPENCLAW_PUBLIC_PORT=8080
 ENV PORT=8080
 EXPOSE 8080
-# When STATE_DIR points outside ~/.openclaw, symlink so components that use
-# the default home path still write to the volume.
+# When STATE_DIR points outside the default home paths, symlink all legacy
+# names (~/.openclaw, ~/.clawdbot, ~/.moltbot) so every code path that
+# resolves state via homedir() lands on the volume.
 CMD ["sh", "-c", "\
   STATE_DIR=\"${OPENCLAW_STATE_DIR:-$CLAWDBOT_STATE_DIR}\"; \
-  if [ -n \"$STATE_DIR\" ] && [ \"$HOME/.openclaw\" != \"$STATE_DIR\" ]; then \
-    mkdir -p \"$STATE_DIR\" && ln -sfn \"$STATE_DIR\" \"$HOME/.openclaw\"; \
+  if [ -n \"$STATE_DIR\" ]; then \
+    mkdir -p \"$STATE_DIR\"; \
+    for name in .openclaw .clawdbot .moltbot; do \
+      [ \"$HOME/$name\" != \"$STATE_DIR\" ] && ln -sfn \"$STATE_DIR\" \"$HOME/$name\"; \
+    done; \
   fi; \
   exec node src/server.js"]


### PR DESCRIPTION
## Problem:
  When OPENCLAW_STATE_DIR points to a volume-backed path (e.g.
  /data/.clawdbot), some OpenClaw components still resolve state via
  homedir(), falling back through ~/.openclaw, ~/.clawdbot, and ~/.moltbot.
  This splits state between the persistent volume and the ephemeral
  container filesystem, causing data loss (device identity, canvas, etc.)
  on every redeploy.

##  Solution:
  At container start, symlink all three legacy home paths (~/.openclaw,
  ~/.clawdbot, ~/.moltbot) to $STATE_DIR so every code path converges on
  the volume. The symlinks are conditional: they only apply when STATE_DIR
  is set, preserving backward compatibility and local smoke tests.

