### PR TITLE
fix: resolve Control UI token mismatch + add device commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "node src/server.js",
     "start": "node src/server.js",
     "lint": "node -c src/server.js",
+    "test": "node --test",
     "smoke": "node scripts/smoke.js"
   },
   "dependencies": {

--- a/src/server.js
+++ b/src/server.js
@@ -309,6 +309,8 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
         <option value="openclaw.logs.tail">openclaw logs --tail N</option>
         <option value="openclaw.config.get">openclaw config get &lt;path&gt;</option>
         <option value="openclaw.version">openclaw --version</option>
+        <option value="openclaw.devices.list">openclaw devices list</option>
+        <option value="openclaw.devices.approve">openclaw devices approve &lt;requestId&gt;</option>
       </select>
       <input id="consoleArg" placeholder="Optional arg (e.g. 200, gateway.port)" style="flex: 1" />
       <button id="consoleRun" style="background:#0f172a">Run</button>
@@ -551,8 +553,11 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
   if (ok) {
     // Ensure gateway token is written into config so the browser UI can authenticate reliably.
     // (We also enforce loopback bind since the wrapper proxies externally.)
+    // IMPORTANT: Set both gateway.auth.token (server-side) and gateway.remote.token (client-side)
+    // to the same value so the Control UI can connect without "token mismatch" errors.
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.auth.mode", "token"]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.auth.token", OPENCLAW_GATEWAY_TOKEN]));
+    await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.remote.token", OPENCLAW_GATEWAY_TOKEN]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.bind", "loopback"]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.port", String(INTERNAL_GATEWAY_PORT)]));
 
@@ -688,6 +693,10 @@ const ALLOWED_CONSOLE_COMMANDS = new Set([
   "openclaw.doctor",
   "openclaw.logs.tail",
   "openclaw.config.get",
+
+  // Device management (for fixing "disconnected (1008): pairing required")
+  "openclaw.devices.list",
+  "openclaw.devices.approve",
 ]);
 
 app.post("/setup/api/console/run", requireSetupAuth, async (req, res) => {
@@ -741,6 +750,23 @@ app.post("/setup/api/console/run", requireSetupAuth, async (req, res) => {
     if (cmd === "openclaw.config.get") {
       if (!arg) return res.status(400).json({ ok: false, error: "Missing config path" });
       const r = await runCmd(OPENCLAW_NODE, clawArgs(["config", "get", arg]));
+      return res.status(r.code === 0 ? 200 : 500).json({ ok: r.code === 0, output: redactSecrets(r.output) });
+    }
+
+    // Device management commands (for fixing "disconnected (1008): pairing required")
+    if (cmd === "openclaw.devices.list") {
+      const r = await runCmd(OPENCLAW_NODE, clawArgs(["devices", "list"]));
+      return res.status(r.code === 0 ? 200 : 500).json({ ok: r.code === 0, output: redactSecrets(r.output) });
+    }
+    if (cmd === "openclaw.devices.approve") {
+      const requestId = String(arg || "").trim();
+      if (!requestId) {
+        return res.status(400).json({ ok: false, error: "Missing device request ID" });
+      }
+      if (!/^[A-Za-z0-9_-]+$/.test(requestId)) {
+        return res.status(400).json({ ok: false, error: "Invalid device request ID" });
+      }
+      const r = await runCmd(OPENCLAW_NODE, clawArgs(["devices", "approve", requestId]));
       return res.status(r.code === 0 ? 200 : 500).json({ ok: r.code === 0, output: redactSecrets(r.output) });
     }
 

--- a/test/server.devices-approve.validation.test.js
+++ b/test/server.devices-approve.validation.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+function validateRequestId(raw) {
+  const requestId = String(raw || "").trim();
+  if (!requestId) return { ok: false, error: "Missing device request ID" };
+  if (!/^[A-Za-z0-9_-]+$/.test(requestId)) return { ok: false, error: "Invalid device request ID" };
+  return { ok: true };
+}
+
+test("devices approve requestId validation: missing", () => {
+  assert.deepEqual(validateRequestId(""), { ok: false, error: "Missing device request ID" });
+  assert.deepEqual(validateRequestId("   "), { ok: false, error: "Missing device request ID" });
+});
+
+test("devices approve requestId validation: rejects weird chars", () => {
+  assert.equal(validateRequestId("../../etc/passwd").ok, false);
+  assert.equal(validateRequestId("abc def").ok, false);
+  assert.equal(validateRequestId("abc$def").ok, false);
+});
+
+test("devices approve requestId validation: allows typical ids", () => {
+  assert.equal(validateRequestId("abc123").ok, true);
+  assert.equal(validateRequestId("req_123-ABC").ok, true);
+});


### PR DESCRIPTION
Port of #50 with a couple hardening tweaks:

- Sets `gateway.remote.token` to match `gateway.auth.token` during setup (fixes Control UI token mismatch / unauthorized)
- Adds `openclaw devices list` and `openclaw devices approve <requestId>` to the debug console allowlist
- Adds requestId validation (alnum/_/- only)
- Adds a small unit test (`node --test`)

Credits: @bamao88
