### PR TITLE
fix: include pnpm in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN apt-get update \
     ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
+# `openclaw update` expects pnpm. Provide it in the runtime image.
+RUN corepack enable && corepack prepare pnpm@10.23.0 --activate
+
 WORKDIR /app
 
 # Wrapper deps


### PR DESCRIPTION
Fixes #53.

`openclaw update` invokes pnpm, but the runtime image didn’t include it, causing `spawn pnpm ENOENT`.

This adds Corepack activation of pnpm in the runtime stage:
- `corepack enable`
- `corepack prepare pnpm@10.23.0 --activate`

No wrapper logic changes.
