### PR TITLE
docs: add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,45 @@ Then:
 4) Copy the **Bot Token** and paste it into `/setup`
 5) Invite the bot to your server (OAuth2 URL Generator → scopes: `bot`, `applications.commands`; then choose permissions)
 
+## Troubleshooting
+
+### “disconnected (1008): pairing required” / dashboard health offline
+
+This is not a crash — it means the gateway is running, but no device has been approved yet.
+
+Fix:
+- Open `/setup`
+- Use the **Debug Console**:
+  - `openclaw devices list`
+  - `openclaw devices approve <requestId>`
+
+### “unauthorized: gateway token mismatch”
+
+The Control UI connects using `gateway.remote.token` and the gateway validates `gateway.auth.token`.
+
+Fix:
+- Re-run `/setup` so the wrapper writes both tokens.
+- Or set both values to the same token in config.
+
+### “Application failed to respond” / 502 Bad Gateway
+
+Most often this means the wrapper is up, but the gateway can’t start or can’t bind.
+
+Checklist:
+- Ensure you mounted a **Volume** at `/data` and set:
+  - `OPENCLAW_STATE_DIR=/data/.openclaw`
+  - `OPENCLAW_WORKSPACE_DIR=/data/workspace`
+- Ensure **Public Networking** is enabled and `PORT=8080`.
+- Check Railway logs for the wrapper error: it will show `Gateway not ready:` with the reason.
+
+### Build OOM (out of memory) on Railway
+
+Building OpenClaw from source can exceed small memory tiers.
+
+Recommendations:
+- Use a plan with **2GB+ memory**.
+- If you see `Reached heap limit Allocation failed - JavaScript heap out of memory`, upgrade memory and redeploy.
+
 ## Local smoke test
 
 ```bash


### PR DESCRIPTION
Adds a README Troubleshooting section covering the most common Railway deploy gotchas:
- pairing required (1008) + how to approve via debug console
- gateway token mismatch explanation
- application failed to respond / 502 checklist
- build OOM guidance

Refs: #15 #55 #64 #38 #41 #19
