### PR TITLE
feat(setup): custom OpenAI-compatible provider (base URL)

### DIFF
--- a/src/setup-app.js
+++ b/src/setup-app.js
@@ -100,7 +100,13 @@
       telegramToken: document.getElementById('telegramToken').value,
       discordToken: document.getElementById('discordToken').value,
       slackBotToken: document.getElementById('slackBotToken').value,
-      slackAppToken: document.getElementById('slackAppToken').value
+      slackAppToken: document.getElementById('slackAppToken').value,
+
+      customProviderId: document.getElementById('customProviderId').value,
+      customProviderBaseUrl: document.getElementById('customProviderBaseUrl').value,
+      customProviderApi: document.getElementById('customProviderApi').value,
+      customProviderApiKeyEnv: document.getElementById('customProviderApiKeyEnv').value,
+      customProviderModelId: document.getElementById('customProviderModelId').value
     };
 
     logEl.textContent = 'Running...\n';


### PR DESCRIPTION
Implements #48 (as much as we can in the template): allow configuring an OpenAI-compatible API with a custom base URL from the /setup wizard.

Adds optional fields to /setup:
- provider id
- baseUrl
- api type (openai-completions vs openai-responses)
- api key env var name (stored as `${ENV_VAR}` reference; user sets env var in Railway)
- optional model id registration

On successful onboarding, the wrapper writes:
- `models.mode=merge`
- `models.providers.<providerId>` JSON

Includes basic validation and prints the command output in the setup log.
