### PR TITLE
chore: add scheduled action to bump OPENCLAW_GIT_REF

### DIFF
--- a/.github/workflows/bump-openclaw-ref.yml
+++ b/.github/workflows/bump-openclaw-ref.yml
@@ -1,0 +1,43 @@
+name: Bump OpenClaw release ref
+
+on:
+  schedule:
+    - cron: "23 9 * * *" # daily 09:23 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Bump Dockerfile OPENCLAW_GIT_REF if needed
+        run: node scripts/bump-openclaw-ref.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump OPENCLAW_GIT_REF to latest release"
+          title: "chore: bump OPENCLAW_GIT_REF to latest OpenClaw release"
+          body: |
+            Automated update of the default OpenClaw build ref (`OPENCLAW_GIT_REF`) to the latest upstream release tag.
+
+            This keeps the Railway template stable-by-default while staying current.
+          branch: chore/bump-openclaw-ref
+          delete-branch: true
+          labels: |
+            automated
+            dependencies

--- a/scripts/bump-openclaw-ref.mjs
+++ b/scripts/bump-openclaw-ref.mjs
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+
+const owner = "openclaw";
+const repo = "openclaw";
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+  console.error("Missing GITHUB_TOKEN");
+  process.exit(2);
+}
+
+async function gh(path) {
+  const url = `https://api.github.com${path}`;
+  const res = await fetch(url, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "user-agent": "clawdbot-railway-template-bot",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+function readCurrentTag(dockerfile) {
+  const m = dockerfile.match(/\nARG OPENCLAW_GIT_REF=([^\n]+)\n/);
+  return m ? m[1].trim() : null;
+}
+
+function replaceTag(dockerfile, next) {
+  const re = /\nARG OPENCLAW_GIT_REF=([^\n]+)\n/;
+  if (!re.test(dockerfile)) throw new Error("Could not find OPENCLAW_GIT_REF line");
+  return dockerfile.replace(re, `\nARG OPENCLAW_GIT_REF=${next}\n`);
+}
+
+const latest = await gh(`/repos/${owner}/${repo}/releases/latest`);
+const latestTag = latest.tag_name;
+if (!latestTag) throw new Error("No tag_name in latest release response");
+
+const dockerPath = "Dockerfile";
+const docker = fs.readFileSync(dockerPath, "utf8");
+const currentTag = readCurrentTag(docker);
+if (!currentTag) throw new Error("Could not parse current OPENCLAW_GIT_REF");
+
+console.log(`current=${currentTag} latest=${latestTag}`);
+
+if (currentTag === latestTag) {
+  console.log("No update needed.");
+  process.exit(0);
+}
+
+fs.writeFileSync(dockerPath, replaceTag(docker, latestTag));
+console.log(`Updated ${dockerPath} to ${latestTag}`);


### PR DESCRIPTION
Adds a daily scheduled GitHub Action (and manual workflow_dispatch) that:
- fetches the latest OpenClaw release tag
- updates Dockerfile `ARG OPENCLAW_GIT_REF=...` when it changes
- opens a PR automatically

This keeps the template stable-by-default while staying up-to-date.
