### PR TITLE
feat: add public /healthz endpoint

### DIFF
--- a/test/healthz.test.js
+++ b/test/healthz.test.js
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Minimal regression guard: ensure the server source contains the public /healthz endpoint.
+// (This repo doesn't have an easy way to import the express app without starting a server.)
+import fs from "node:fs";
+
+test("server exposes /healthz endpoint", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  assert.match(src, /app\.get\("\/healthz"/);
+});


### PR DESCRIPTION
Adds a public (no-auth) `/healthz` endpoint to make Railway probes and “is it up?” checks easier.

Returns:
- wrapper configured state
- gateway target + reachability probe (only if configured)
- last gateway error/exit breadcrumbs

Includes a tiny regression test guarding the route’s presence.
