### PR TITLE
feat(setup): hide interactive OAuth providers by default

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -485,6 +485,7 @@ app.get("/setup/api/status", requireSetupAuth, async (_req, res) => {
 
   // We reuse OpenClaw's own auth-choice grouping logic indirectly by hardcoding the same group defs.
   // This is intentionally minimal; later we can parse the CLI help output to stay perfectly in sync.
+  // NOTE: On Railway, interactive OAuth flows are typically not viable. The UI will hide them by default.
   const authGroups = [
     { value: "openai", label: "OpenAI", hint: "Codex OAuth + API key", options: [
       { value: "codex-cli", label: "OpenAI Codex OAuth (Codex CLI)" },


### PR DESCRIPTION
Makes Railway onboarding more “one-click” by hiding interactive OAuth auth choices by default.

- Adds a UI checkbox: “Show interactive OAuth options (advanced)”
- Filters auth choices that look interactive (label contains OAuth, or value contains cli/codex/portal)
- Prefers selecting a non-interactive option by default

This is UI-only; no behavior change unless the user opts into advanced OAuth choices.
