### PR TITLE
feat(setup): improve status block (gateway target + health hint)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -341,6 +341,7 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
   <div class="card">
     <h2>Status</h2>
     <div id="status">Loading...</div>
+    <div id="statusDetails" class="muted" style="margin-top:0.5rem"></div>
     <div style="margin-top: 0.75rem">
       <a href="/openclaw" target="_blank">Open OpenClaw UI</a>
       &nbsp;|&nbsp;

--- a/src/setup-app.js
+++ b/src/setup-app.js
@@ -3,6 +3,7 @@
 
 (function () {
   var statusEl = document.getElementById('status');
+  var statusDetailsEl = document.getElementById('statusDetails');
   var authGroupEl = document.getElementById('authGroup');
   var authChoiceEl = document.getElementById('authChoice');
   var logEl = document.getElementById('log');
@@ -104,10 +105,21 @@
 
   function refreshStatus() {
     setStatus('Loading...');
+    if (statusDetailsEl) statusDetailsEl.textContent = '';
+
     return httpJson('/setup/api/status').then(function (j) {
       var ver = j.openclawVersion ? (' | ' + j.openclawVersion) : '';
-      setStatus((j.configured ? 'Configured - open /openclaw' : 'Not configured - run setup below') + ver);
+      setStatus((j.configured ? 'Configured' : 'Not configured - run setup below') + ver);
+
+      if (statusDetailsEl) {
+        var parts = [];
+        parts.push('Gateway target: ' + (j.gatewayTarget || '(unknown)'));
+        parts.push('Tip: /healthz shows wrapper+gateway reachability.');
+        statusDetailsEl.textContent = parts.join('\n');
+      }
+
       renderAuth(j.authGroups || []);
+
       // If channels are unsupported, surface it for debugging.
       if (j.channelsAddHelp && j.channelsAddHelp.indexOf('telegram') === -1) {
         logEl.textContent += '\nNote: this openclaw build does not list telegram in `channels add --help`. Telegram auto-add will be skipped.\n';
@@ -120,6 +132,7 @@
 
     }).catch(function (e) {
       setStatus('Error: ' + String(e));
+      if (statusDetailsEl) statusDetailsEl.textContent = '';
     });
   }
 


### PR DESCRIPTION
Small, low-risk UX improvement to make the setup page more self-serve:
- shows gateway target in the Status card
- points users at `/healthz` for quick wrapper+gateway reachability checks

No behavior changes.
