### PR TITLE
feat(setup): add plugin commands to debug console

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -373,6 +373,8 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
         <option value="openclaw.version">openclaw --version</option>
         <option value="openclaw.devices.list">openclaw devices list</option>
         <option value="openclaw.devices.approve">openclaw devices approve &lt;requestId&gt;</option>
+        <option value="openclaw.plugins.list">openclaw plugins list</option>
+        <option value="openclaw.plugins.enable">openclaw plugins enable &lt;name&gt;</option>
       </select>
       <input id="consoleArg" placeholder="Optional arg (e.g. 200, gateway.port)" style="flex: 1" />
       <button id="consoleRun" style="background:#0f172a">Run</button>
@@ -860,6 +862,10 @@ const ALLOWED_CONSOLE_COMMANDS = new Set([
   // Device management (for fixing "disconnected (1008): pairing required")
   "openclaw.devices.list",
   "openclaw.devices.approve",
+
+  // Plugin management
+  "openclaw.plugins.list",
+  "openclaw.plugins.enable",
 ]);
 
 app.post("/setup/api/console/run", requireSetupAuth, async (req, res) => {
@@ -930,6 +936,19 @@ app.post("/setup/api/console/run", requireSetupAuth, async (req, res) => {
         return res.status(400).json({ ok: false, error: "Invalid device request ID" });
       }
       const r = await runCmd(OPENCLAW_NODE, clawArgs(["devices", "approve", requestId]));
+      return res.status(r.code === 0 ? 200 : 500).json({ ok: r.code === 0, output: redactSecrets(r.output) });
+    }
+
+    // Plugin management commands
+    if (cmd === "openclaw.plugins.list") {
+      const r = await runCmd(OPENCLAW_NODE, clawArgs(["plugins", "list"]));
+      return res.status(r.code === 0 ? 200 : 500).json({ ok: r.code === 0, output: redactSecrets(r.output) });
+    }
+    if (cmd === "openclaw.plugins.enable") {
+      const name = String(arg || "").trim();
+      if (!name) return res.status(400).json({ ok: false, error: "Missing plugin name" });
+      if (!/^[A-Za-z0-9_-]+$/.test(name)) return res.status(400).json({ ok: false, error: "Invalid plugin name" });
+      const r = await runCmd(OPENCLAW_NODE, clawArgs(["plugins", "enable", name]));
       return res.status(r.code === 0 ? 200 : 500).json({ ok: r.code === 0, output: redactSecrets(r.output) });
     }
 

--- a/test/plugins-console.test.js
+++ b/test/plugins-console.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("debug console exposes plugins list/enable", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  assert.match(src, /openclaw\.plugins\.list/);
+  assert.match(src, /openclaw\.plugins\.enable/);
+});


### PR DESCRIPTION
Adds `openclaw plugins list` and `openclaw plugins enable <name>` to the /setup Debug Console allowlist.

This helps users enable bundled auth plugins (e.g. qwen-portal-auth) without needing SSH.

Includes basic arg validation and a small regression test.
