### PR TITLE
feat: capture openclaw doctor output on gateway start failure

### DIFF
--- a/test/doctor-breadcrumbs.test.js
+++ b/test/doctor-breadcrumbs.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("debug JSON includes lastDoctor fields", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  assert.match(src, /lastDoctorOutput/);
+  assert.match(src, /lastDoctorAt/);
+});


### PR DESCRIPTION
When the gateway fails to start, users often have no actionable logs.

This adds a fail-soft diagnostic step:
- On gateway start failure, run `openclaw doctor` (rate-limited) and stash redacted output in memory.
- Expose `lastDoctorAt` and `lastDoctorOutput` via `/setup/api/debug`.
- Expose `lastDoctorAt` via `/healthz` (no secrets).

Includes a small regression test.
