### PR TITLE
Improve /setup wizard UX and support direct Railway deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,10 @@ WORKDIR /app
 # Wrapper deps
 COPY package.json ./
 RUN npm install --omit=dev && npm cache clean --force
+# Patch http-proxy: replace deprecated util._extend with Object.assign (no upstream fix).
+RUN sed -i "s/require('util')._extend/Object.assign/g" \
+    node_modules/http-proxy/lib/http-proxy/index.js \
+    node_modules/http-proxy/lib/http-proxy/common.js
 
 # Copy built openclaw
 COPY --from=openclaw-build /openclaw /openclaw

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ docker build -t openclaw-railway-template .
 docker run --rm -p 8080:8080 \
   -e PORT=8080 \
   -e SETUP_PASSWORD=test \
+  -e OPENCLAW_GATEWAY_TOKEN=test \
   -e OPENCLAW_STATE_DIR=/data/.openclaw \
   -e OPENCLAW_WORKSPACE_DIR=/data/workspace \
   -v $(pwd)/.tmpdata:/data \

--- a/railway.toml
+++ b/railway.toml
@@ -5,6 +5,11 @@ builder = "dockerfile"
 healthcheckPath = "/setup/healthz"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"
+requiredMountPath = "/data"
 
 [variables]
 PORT = "8080"
+SETUP_PASSWORD = ""
+OPENCLAW_STATE_DIR = "/data/.openclaw"
+OPENCLAW_GATEWAY_TOKEN = ""
+OPENCLAW_WORKSPACE_DIR = "/data/workspace"

--- a/src/server.js
+++ b/src/server.js
@@ -414,6 +414,7 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
     <pre id="configOut" style="white-space:pre-wrap"></pre>
   </div>
 
+  <form id="setupForm">
   <div class="card">
     <h2>1) Model/auth provider</h2>
     <p class="muted">Matches the groups shown in the terminal onboarding.</p>
@@ -425,13 +426,42 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
 
     <label>Key / Token (if required)</label>
     <input id="authSecret" type="password" placeholder="Paste API key / token if applicable" />
+  </div>
 
-    <label>Wizard flow</label>
-    <select id="flow">
-      <option value="quickstart">quickstart</option>
-      <option value="advanced">advanced</option>
-      <option value="manual">manual</option>
+  <div class="card">
+    <h2>1b) Advanced: Custom provider (optional)</h2>
+    <p class="muted">Use this to configure an OpenAI-compatible or Anthropic-compatible API that requires a custom base URL (e.g. Ollama, vLLM, LM Studio, MiniMax, hosted proxies).</p>
+
+    <label>Provider id (e.g. ollama, deepseek, myproxy)</label>
+    <input id="customProviderId" placeholder="ollama" />
+
+    <label>API protocol</label>
+    <select id="customProviderApi">
+      <option value="openai-completions">openai-completions</option>
+      <option value="openai-responses">openai-responses</option>
+      <option value="anthropic-messages">anthropic-messages</option>
     </select>
+
+    <label>Base URL</label>
+    <input id="customProviderBaseUrl" placeholder="http://127.0.0.1:11434/v1" />
+    <div class="muted" style="margin-top: 0.25rem" id="customProviderUrlHint">
+      OpenAI-compatible: must include <code>/v1</code> (e.g. <code>http://host:11434/v1</code>). Anthropic-compatible: no <code>/v1</code> (e.g. <code>https://api.kimi.com/coding/</code>).
+    </div>
+
+    <label>API key env var name (optional, e.g. OLLAMA_API_KEY)</label>
+    <input id="customProviderApiKeyEnv" placeholder="e.g. OLLAMA_API_KEY" />
+    <div class="muted" style="margin-top: 0.25rem">
+      Set the key as a Railway variable and reference it here. The config will resolve <code>\${VAR_NAME}</code> at runtime. Leave blank if the provider doesn't require one (e.g. local Ollama).
+    </div>
+
+    <label>...or paste API key directly</label>
+    <input id="customProviderApiKey" type="password" placeholder="Paste API key if required" />
+    <div class="muted" style="margin-top: 0.25rem">
+      Ignored if an env var is provided above. Note: this value is stored in plain text in the config file.
+    </div>
+
+    <label>Optional model id(s), comma-separated (e.g. llama3.1:8b, gpt-4o)</label>
+    <input id="customProviderModelId" placeholder="" />
   </div>
 
   <div class="card">
@@ -459,33 +489,10 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
   </div>
 
   <div class="card">
-    <h2>2b) Advanced: Custom OpenAI-compatible provider (optional)</h2>
-    <p class="muted">Use this to configure an OpenAI-compatible API that requires a custom base URL (e.g. Ollama, vLLM, LM Studio, hosted proxies). You usually set the API key as a Railway variable and reference it here.</p>
-
-    <label>Provider id (e.g. ollama, deepseek, myproxy)</label>
-    <input id="customProviderId" placeholder="ollama" />
-
-    <label>Base URL (must include /v1, e.g. http://host:11434/v1)</label>
-    <input id="customProviderBaseUrl" placeholder="http://127.0.0.1:11434/v1" />
-
-    <label>API (openai-completions or openai-responses)</label>
-    <select id="customProviderApi">
-      <option value="openai-completions">openai-completions</option>
-      <option value="openai-responses">openai-responses</option>
-    </select>
-
-    <label>API key env var name (optional, e.g. OLLAMA_API_KEY). Leave blank for no key.</label>
-    <input id="customProviderApiKeyEnv" placeholder="OLLAMA_API_KEY" />
-
-    <label>Optional model id to register (e.g. llama3.1:8b)</label>
-    <input id="customProviderModelId" placeholder="" />
-  </div>
-
-  <div class="card">
     <h2>3) Run onboarding</h2>
-    <button id="run">Run setup</button>
-    <button id="pairingApprove" style="background:#1f2937; margin-left:0.5rem">Approve pairing</button>
-    <button id="reset" style="background:#444; margin-left:0.5rem">Reset setup</button>
+    <button type="submit" id="run">Run setup</button>
+    <button type="button" id="pairingApprove" style="background:#1f2937; margin-left:0.5rem">Approve pairing</button>
+    <button type="button" id="reset" style="background:#444; margin-left:0.5rem">Reset setup</button>
     <pre id="log" style="white-space:pre-wrap"></pre>
     <p class="muted">Reset deletes the OpenClaw config file so you can rerun onboarding. Pairing approval lets you grant DM access when dmPolicy=pairing.</p>
 
@@ -496,6 +503,7 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
       <div id="devicesList" class="muted" style="margin-top:0.5rem"></div>
     </details>
   </div>
+  </form>
 
   <script src="/setup/app.js"></script>
 </body>
@@ -585,8 +593,6 @@ function buildOnboardArgs(payload) {
     "token",
     "--gateway-token",
     OPENCLAW_GATEWAY_TOKEN,
-    "--flow",
-    payload.flow || "quickstart",
   ];
 
   if (payload.authChoice) {
@@ -699,22 +705,25 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
       const baseUrl = payload.customProviderBaseUrl.trim();
       const api = (payload.customProviderApi || "openai-completions").trim();
       const apiKeyEnv = (payload.customProviderApiKeyEnv || "").trim();
+      const apiKeyDirect = (payload.customProviderApiKey || "").trim();
       const modelId = (payload.customProviderModelId || "").trim();
 
       if (!/^[A-Za-z0-9_-]+$/.test(providerId)) {
         extra += `\n[custom provider] skipped: invalid provider id (use letters/numbers/_/-)`;
       } else if (!/^https?:\/\//.test(baseUrl)) {
         extra += `\n[custom provider] skipped: baseUrl must start with http(s)://`;
-      } else if (api !== "openai-completions" && api !== "openai-responses") {
-        extra += `\n[custom provider] skipped: api must be openai-completions or openai-responses`;
+      } else if (api !== "openai-completions" && api !== "openai-responses" && api !== "anthropic-messages") {
+        extra += `\n[custom provider] skipped: api must be openai-completions, openai-responses, or anthropic-messages`;
       } else if (apiKeyEnv && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(apiKeyEnv)) {
         extra += `\n[custom provider] skipped: invalid api key env var name`;
       } else {
         const providerCfg = {
           baseUrl,
           api,
-          apiKey: apiKeyEnv ? "${" + apiKeyEnv + "}" : undefined,
-          models: modelId ? [{ id: modelId, name: modelId }] : undefined,
+          apiKey: apiKeyEnv ? "${" + apiKeyEnv + "}" : (apiKeyDirect ? apiKeyDirect : undefined),
+          models: modelId
+            ? modelId.split(',').map(function (m) { var t = m.trim(); return { id: t, name: t, input: ["text", "image"] }; })
+            : [],
         };
 
         // Ensure we merge in this provider rather than replacing other providers.
@@ -724,6 +733,14 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
           clawArgs(["config", "set", "--json", `models.providers.${providerId}`, JSON.stringify(providerCfg)]),
         );
         extra += `\n[custom provider] exit=${set.code} (output ${set.output.length} chars)\n${set.output || "(no output)"}`;
+
+        // Register each model in agents.defaults.models so /models can see them.
+        const models = providerCfg.models || [];
+        for (const m of models) {
+          const key = `${providerId}/${m.id}`;
+          await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "--json", `agents.defaults.models.${key}`, "{}"]));
+          extra += `\n[model registered] ${key}`;
+        }
       }
     }
 

--- a/src/setup-app.js
+++ b/src/setup-app.js
@@ -46,7 +46,7 @@
       advancedToggle.style.display = 'block';
       advancedToggle.style.marginTop = '0.5rem';
       advancedToggle.innerHTML = '<input type="checkbox" id="showAdvancedAuth" /> Show interactive OAuth options (advanced)';
-      authGroupEl.parentNode.insertBefore(advancedToggle, authChoiceEl.parentNode);
+      authChoiceEl.parentNode.insertBefore(advancedToggle, authChoiceEl.nextSibling);
     }
 
     for (var i = 0; i < groups.length; i++) {
@@ -136,9 +136,10 @@
     });
   }
 
-  document.getElementById('run').onclick = function () {
+  document.getElementById('setupForm').addEventListener('submit', function (e) {
+    e.preventDefault();
+
     var payload = {
-      flow: document.getElementById('flow').value,
       authChoice: authChoiceEl.value,
       authSecret: document.getElementById('authSecret').value,
       telegramToken: document.getElementById('telegramToken').value,
@@ -149,6 +150,7 @@
       customProviderId: document.getElementById('customProviderId').value,
       customProviderBaseUrl: document.getElementById('customProviderBaseUrl').value,
       customProviderApi: document.getElementById('customProviderApi').value,
+      customProviderApiKey: document.getElementById('customProviderApiKey').value,
       customProviderApiKeyEnv: document.getElementById('customProviderApiKeyEnv').value,
       customProviderModelId: document.getElementById('customProviderModelId').value
     };
@@ -170,7 +172,7 @@
     }).catch(function (e) {
       logEl.textContent += '\nError: ' + String(e) + '\n';
     });
-  };
+  });
 
   // Debug console runner
   function runConsole() {


### PR DESCRIPTION
- Add env vars to railway.toml (SETUP_PASSWORD, OPENCLAW_STATE_DIR, OPENCLAW_GATEWAY_TOKEN, OPENCLAW_WORKSPACE_DIR) so the repo can be deployed directly without the pre-defined Railway template
- Remove wizard flow selector (quickstart/advanced/manual) — had no effect in non-interactive mode
- Move custom provider section from 2b to 1b and extend it to support Anthropic-compatible APIs (anthropic-messages protocol)
- Add direct API key input alongside env var reference, env var takes precedence
- Support comma-separated model IDs for custom providers
- Use HTML form validation (required attribute) instead of custom JS
- Fix template literal escaping for ${VAR_NAME} in HTML strings
- Fix custom provider models field: use [] instead of undefined