### PR TITLE
chore(railway): require /data mount + default state/workspace dirs

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -6,5 +6,10 @@ healthcheckPath = "/setup/healthz"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"
 
+# Require a persistent volume mounted at /data (Railway).
+requiredMountPath = "/data"
+
 [variables]
 PORT = "8080"
+OPENCLAW_STATE_DIR = "/data/.openclaw"
+OPENCLAW_WORKSPACE_DIR = "/data/workspace"


### PR DESCRIPTION
Refines railway.toml for direct deploys:

- sets requiredMountPath=/data
- defaults OPENCLAW_STATE_DIR and OPENCLAW_WORKSPACE_DIR to /data paths

Inspired by #88, but kept intentionally minimal to avoid regressions.