### PR TITLE
fix: configure gateway.trustedProxies for Railway

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -695,6 +695,13 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.bind", "loopback"]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.port", String(INTERNAL_GATEWAY_PORT)]));
 
+    // Railway runs behind a reverse proxy. Trust loopback as a proxy hop so local client detection
+    // remains correct when X-Forwarded-* headers are present.
+    await runCmd(
+      OPENCLAW_NODE,
+      clawArgs(["config", "set", "--json", "gateway.trustedProxies", JSON.stringify(["127.0.0.1"]) ]),
+    );
+
     // Optional: configure a custom OpenAI-compatible provider (base URL) for advanced users.
     if (payload.customProviderId?.trim() && payload.customProviderBaseUrl?.trim()) {
       const providerId = payload.customProviderId.trim();

--- a/test/trusted-proxies-config.test.js
+++ b/test/trusted-proxies-config.test.js
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("setup writes gateway.trustedProxies", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  assert.match(src, /gateway\.trustedProxies/);
+});


### PR DESCRIPTION
Fixes #81.

Writes `gateway.trustedProxies=["127.0.0.1"]` after onboarding so OpenClaw trusts the wrapper as a proxy hop (prevents WS local-client warnings behind Railway).

Includes a small regression test.
