### PR TITLE
chore: update links after repo rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for helping improve the OpenClaw Railway Template.
 ## Where to ask questions / get help
 
 - Discord: https://discord.com/invite/clawd
-- GitHub Issues: https://github.com/vignesh07/clawdbot-railway-template/issues
+- GitHub Issues: https://github.com/vignesh07/openclaw-railway-template/issues
 
 ## Reporting bugs
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then:
 
 ## Support / community
 
-- GitHub Issues: https://github.com/vignesh07/clawdbot-railway-template/issues
+- GitHub Issues: https://github.com/vignesh07/openclaw-railway-template/issues
 - Discord: https://discord.com/invite/clawd
 
 If you’re filing a bug, please include the output of:


### PR DESCRIPTION
Updates README/CONTRIBUTING links to point at the new repo slug after rename.