### PR TITLE
chore(debug): add Telegram pairing diagnostics

### DIFF
--- a/test/redact-secrets.test.js
+++ b/test/redact-secrets.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+function getRedactor() {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  const m = src.match(/function redactSecrets\(text\) \{([\s\S]*?)\n\}/);
+  assert.ok(m, "redactSecrets not found");
+  // eslint-disable-next-line no-new-func
+  return new Function("return function redactSecrets(text){" + m[1] + "\n}" )();
+}
+
+test("redactSecrets redacts Telegram bot tokens", () => {
+  const redact = getRedactor();
+  const s = "botToken: 123456789:AAABBBcccDDD_eee-FFF";
+  const out = redact(s);
+  assert.ok(!out.includes("123456789:"));
+  assert.match(out, /\[REDACTED\]/);
+});


### PR DESCRIPTION
Hardens /setup/api/debug to include redacted telegram/discord channel config checks + gatewayRunning flag, and adds redaction for Telegram bot tokens.

This makes reports like “pairing not working” actionable instead of silent.

Refs #96.