### PR TITLE
fix: healthz gateway probe + auto doctor --fix after setup

### DIFF
--- a/test/healthz-probe.test.js
+++ b/test/healthz-probe.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("healthz implements probeGateway (TCP connect)", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  assert.match(src, /async function probeGateway\(/);
+  assert.match(src, /node:net/);
+});


### PR DESCRIPTION
- Fixes /healthz reachability check: implement probeGateway via TCP connect (no longer always false when configured).
- Runs `openclaw doctor --fix` after setup changes and restarts gateway again, so channels like Telegram don’t remain "configured, not enabled yet".

This should make Telegram pairing work out-of-the-box and make healthz accurate.
