### PR TITLE
chore: rename links/package back to clawdbot-railway-template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for helping improve the OpenClaw Railway Template.
 ## Where to ask questions / get help
 
 - Discord: https://discord.com/invite/clawd
-- GitHub Issues: https://github.com/vignesh07/openclaw-railway-template/issues
+- GitHub Issues: https://github.com/vignesh07/clawdbot-railway-template/issues
 
 ## Reporting bugs
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then:
 
 ## Support / community
 
-- GitHub Issues: https://github.com/vignesh07/openclaw-railway-template/issues
+- GitHub Issues: https://github.com/vignesh07/clawdbot-railway-template/issues
 - Discord: https://discord.com/invite/clawd
 
 If you’re filing a bug, please include the output of:
@@ -113,7 +113,7 @@ Recommendations:
 ## Local smoke test
 
 ```bash
-docker build -t openclaw-railway-template .
+docker build -t clawdbot-railway-template .
 
 docker run --rm -p 8080:8080 \
   -e PORT=8080 \
@@ -121,7 +121,7 @@ docker run --rm -p 8080:8080 \
   -e OPENCLAW_STATE_DIR=/data/.openclaw \
   -e OPENCLAW_WORKSPACE_DIR=/data/workspace \
   -v $(pwd)/.tmpdata:/data \
-  openclaw-railway-template
+  clawdbot-railway-template
 
 # open http://localhost:8080/setup (password: test)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "openclaw-railway-template",
+  "name": "clawdbot-railway-template",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openclaw-railway-template",
+      "name": "clawdbot-railway-template",
       "dependencies": {
         "express": "^5.1.0",
         "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openclaw-railway-template",
+  "name": "clawdbot-railway-template",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/bump-openclaw-ref.mjs
+++ b/scripts/bump-openclaw-ref.mjs
@@ -14,7 +14,7 @@ async function gh(path) {
     headers: {
       authorization: `Bearer ${token}`,
       accept: "application/vnd.github+json",
-      "user-agent": "openclaw-railway-template-bot",
+      "user-agent": "clawdbot-railway-template-bot",
     },
   });
   if (!res.ok) {


### PR DESCRIPTION
Renames package metadata + docs links back to the original repo slug after reverting the GitHub repo rename.