### PR TITLE
fix(setup): auth provider dropdowns load instantly

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -442,10 +442,14 @@ app.get("/setup", requireSetupAuth, (_req, res) => {
     <h2>1) Model/auth provider</h2>
     <p class="muted">Matches the groups shown in the terminal onboarding.</p>
     <label>Provider group</label>
-    <select id="authGroup"></select>
+    <select id="authGroup">
+      <option>Loading providers…</option>
+    </select>
 
     <label>Auth method</label>
-    <select id="authChoice"></select>
+    <select id="authChoice">
+      <option>Loading methods…</option>
+    </select>
 
     <label>Key / Token (if required)</label>
     <input id="authSecret" type="password" placeholder="Paste API key / token if applicable" />


### PR DESCRIPTION
Fixes #105.

- Add placeholder options so selects aren’t blank before JS runs.
- Load auth groups via the fast `/setup/api/auth-groups` endpoint on page load (no subprocess spawn), while `/setup/api/status` continues loading version/help in parallel.

Tests: pnpm lint && pnpm test
