### PR TITLE
Fix Railway template: respect injected PORT + stop legacy CLAWDBOT var noise

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,9 @@ RUN printf '%s\n' '#!/usr/bin/env bash' 'exec node /openclaw/dist/entry.js "$@"'
 COPY src ./src
 
 # The wrapper listens on this port.
-ENV OPENCLAW_PUBLIC_PORT=8080
+# IMPORTANT: Do not hardcode a public listen port here.
+# Railway injects PORT at runtime and routes traffic to that port.
+# If we force a different port, deployments can come up but the domain will route elsewhere.
 ENV PORT=8080
 EXPOSE 8080
 CMD ["node", "src/server.js"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Notes:
 - This template pins OpenClaw to a released version by default via Docker build arg `OPENCLAW_GIT_REF` (override if you want `main`).
 
 4) Enable **Public Networking** (HTTP). Railway will assign a domain.
-   - This service is configured to listen on port `8080` (including custom domains).
+   - This service listens on Railway’s injected `PORT` at runtime (recommended).
 5) Deploy.
 
 Then:
@@ -99,7 +99,7 @@ Checklist:
 - Ensure you mounted a **Volume** at `/data` and set:
   - `OPENCLAW_STATE_DIR=/data/.openclaw`
   - `OPENCLAW_WORKSPACE_DIR=/data/workspace`
-- Ensure **Public Networking** is enabled and `PORT=8080`.
+- Ensure **Public Networking** is enabled (Railway will inject `PORT`).
 - Check Railway logs for the wrapper error: it will show `Gateway not ready:` with the reason.
 
 ### Build OOM (out of memory) on Railway

--- a/railway.toml
+++ b/railway.toml
@@ -10,6 +10,8 @@ restartPolicyType = "on_failure"
 requiredMountPath = "/data"
 
 [variables]
-PORT = "8080"
+# NOTE: Railway injects PORT automatically.
+# Do not set PORT here; Railway templates may not apply it reliably and hardcoding
+# can cause domain routing mismatches.
 OPENCLAW_STATE_DIR = "/data/.openclaw"
 OPENCLAW_WORKSPACE_DIR = "/data/workspace"

--- a/src/server.js
+++ b/src/server.js
@@ -15,20 +15,17 @@ for (const suffix of ["PUBLIC_PORT", "STATE_DIR", "WORKSPACE_DIR", "GATEWAY_TOKE
   const newKey = `OPENCLAW_${suffix}`;
   if (process.env[oldKey] && !process.env[newKey]) {
     process.env[newKey] = process.env[oldKey];
-    console.warn(`[migration] Copied ${oldKey} → ${newKey}. Please rename this variable in your Railway settings.`);
+    // Best-effort compatibility shim for old Railway templates.
+    // Intentionally no warning: Railway templates can still set legacy keys and warnings are noisy.
   }
 }
 
-// Railway deployments sometimes inject PORT=3000 by default. We want the wrapper to
-// reliably listen on 8080 unless explicitly overridden.
+// Railway injects PORT at runtime and routes traffic to that port.
+// Do not force a different public port in the container image, or the service may
+// boot but the Railway domain will be routed to a different port.
 //
-// Prefer OPENCLAW_PUBLIC_PORT (set in the Dockerfile / template) over PORT.
-const PORT = Number.parseInt(
-  process.env.OPENCLAW_PUBLIC_PORT?.trim() ??
-    process.env.PORT ??
-    "8080",
-  10,
-);
+// OPENCLAW_PUBLIC_PORT is kept as an escape hatch for non-Railway deployments.
+const PORT = Number.parseInt(process.env.PORT ?? process.env.OPENCLAW_PUBLIC_PORT ?? "3000", 10);
 
 // State/workspace
 // OpenClaw defaults to ~/.openclaw.


### PR DESCRIPTION
Fixes Railway template regressions reported by @vgnsh.

Changes:
- Do not hardcode OPENCLAW_PUBLIC_PORT=8080 in the image. Railway routes to the injected PORT; forcing 8080 can cause the service to boot on 8080 while Railway routes the domain to 3000.
- Wrapper listen port is now PORT (fallback 3000). OPENCLAW_PUBLIC_PORT remains as a non-Railway escape hatch.
- Remove PORT from railway.toml variables section (Railway injects it; template application is inconsistent).
- Keep CLAWDBOT_* → OPENCLAW_* env migration but silence warnings (templates may still set legacy keys).

Tests:
- npm test
