### PR TITLE
Fix Railway PORT mismatch (don't hardcode PORT in image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,9 @@ RUN printf '%s\n' '#!/usr/bin/env bash' 'exec node /openclaw/dist/entry.js "$@"'
 
 COPY src ./src
 
-# The wrapper listens on this port.
-# IMPORTANT: Do not hardcode a public listen port here.
+# The wrapper listens on $PORT.
+# IMPORTANT: Do not set a default PORT here.
 # Railway injects PORT at runtime and routes traffic to that port.
 # If we force a different port, deployments can come up but the domain will route elsewhere.
-ENV PORT=8080
-EXPOSE 8080
+EXPOSE 3000
 CMD ["node", "src/server.js"]

--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ Recommendations:
 ```bash
 docker build -t clawdbot-railway-template .
 
-docker run --rm -p 8080:8080 \
-  -e PORT=8080 \
+docker run --rm -p 3000:3000 \
+  -e PORT=3000 \
   -e SETUP_PASSWORD=test \
   -e OPENCLAW_STATE_DIR=/data/.openclaw \
   -e OPENCLAW_WORKSPACE_DIR=/data/workspace \
   -v $(pwd)/.tmpdata:/data \
   clawdbot-railway-template
 
-# open http://localhost:8080/setup (password: test)
+# open http://localhost:3000/setup (password: test)
 ```
 
 ---


### PR DESCRIPTION
Fixes #127.

Railway injects `PORT` at runtime; the Dockerfile previously set `ENV PORT=8080`, which caused the wrapper to ignore Railway's injected port and break public routing.

Changes:
- Remove hardcoded `ENV PORT=...` from Dockerfile
- Set `EXPOSE 3000` to match the server default (still overrideable via `PORT`)
- Update README local smoke test to use port 3000

Tests:
- `npm test`
