### PR TITLE
Fix zombie processes: run wrapper under tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ENV NODE_ENV=production
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
+    tini \
   && rm -rf /var/lib/apt/lists/*
 
 # `openclaw update` expects pnpm. Provide it in the runtime image.
@@ -71,4 +72,7 @@ COPY src ./src
 # Railway injects PORT at runtime and routes traffic to that port.
 # If we force a different port, deployments can come up but the domain will route elsewhere.
 EXPOSE 3000
+
+# Ensure PID 1 reaps zombies and forwards signals.
+ENTRYPOINT ["tini", "--"]
 CMD ["node", "src/server.js"]


### PR DESCRIPTION
Fixes #134.

In containers, having Node as PID 1 can lead to unreaped zombie child processes when subprocesses exit.

This change installs `tini` in the runtime image and uses it as ENTRYPOINT so PID 1:
- reaps zombie processes
- forwards signals cleanly

Changes:
- Dockerfile: install `tini`
- Dockerfile: set `ENTRYPOINT ["tini", "--"]`

Tests:
- `npm test`
