### PR TITLE
Fix 502 on Railway: expose 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ COPY src ./src
 # IMPORTANT: Do not set a default PORT here.
 # Railway injects PORT at runtime and routes traffic to that port.
 # If we force a different port, deployments can come up but the domain will route elsewhere.
-EXPOSE 3000
+EXPOSE 8080
 
 # Ensure PID 1 reaps zombies and forwards signals.
 ENTRYPOINT ["tini", "--"]

--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ Recommendations:
 ```bash
 docker build -t clawdbot-railway-template .
 
-docker run --rm -p 3000:3000 \
-  -e PORT=3000 \
+docker run --rm -p 8080:8080 \
+  -e PORT=8080 \
   -e SETUP_PASSWORD=test \
   -e OPENCLAW_STATE_DIR=/data/.openclaw \
   -e OPENCLAW_WORKSPACE_DIR=/data/workspace \
   -v $(pwd)/.tmpdata:/data \
   clawdbot-railway-template
 
-# open http://localhost:3000/setup (password: test)
+# open http://localhost:8080/setup (password: test)
 ```
 
 ---


### PR DESCRIPTION
Fixes #132.

Railway commonly routes to the port it detects from the image (EXPOSE) / service networking settings.
Our wrapper listens on Railway’s injected `PORT` (often 8080), but the Dockerfile was exposing 3000, which can cause Railway to route to the wrong port → 502 even though logs show the wrapper listening.

Changes:
- Dockerfile: `EXPOSE 8080`
- README: local smoke test defaults to 8080

Tests:
- `npm test`
