### PR TITLE
Docs: persistence on Railway (/data) + bootstrap hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,21 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     tini \
+    python3 \
+    python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
 # `openclaw update` expects pnpm. Provide it in the runtime image.
 RUN corepack enable && corepack prepare pnpm@10.23.0 --activate
+
+# Persist user-installed tools by default by targeting the Railway volume.
+# - npm global installs -> /data/npm
+# - pnpm global installs -> /data/pnpm (binaries) + /data/pnpm-store (store)
+ENV NPM_CONFIG_PREFIX=/data/npm
+ENV NPM_CONFIG_CACHE=/data/npm-cache
+ENV PNPM_HOME=/data/pnpm
+ENV PNPM_STORE_DIR=/data/pnpm-store
+ENV PATH="/data/npm/bin:/data/pnpm:${PATH}"
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,39 @@ If you’re filing a bug, please include the output of:
 4) Copy the **Bot Token** and paste it into `/setup`
 5) Invite the bot to your server (OAuth2 URL Generator → scopes: `bot`, `applications.commands`; then choose permissions)
 
+## Persistence (Railway volume)
+
+Railway containers have an ephemeral filesystem. Only the mounted volume at `/data` persists across restarts/redeploys.
+
+What persists cleanly today:
+- **Custom skills / code:** anything under `OPENCLAW_WORKSPACE_DIR` (default: `/data/workspace`)
+- **Node global tools (npm/pnpm):** this template configures defaults so global installs land under `/data`:
+  - npm globals: `/data/npm` (binaries in `/data/npm/bin`)
+  - pnpm globals: `/data/pnpm` (binaries) + `/data/pnpm-store` (store)
+- **Python packages:** create a venv under `/data` (example below). The runtime image includes Python + venv support.
+
+What does *not* persist cleanly:
+- `apt-get install ...` (installs into `/usr/*`)
+- Homebrew installs (typically `/opt/homebrew` or similar)
+
+### Optional bootstrap hook
+
+If `/data/workspace/bootstrap.sh` exists, the wrapper will run it on startup (best-effort) before starting the gateway.
+Use this to initialize persistent install prefixes or create a venv.
+
+Example `bootstrap.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Example: create a persistent python venv
+python3 -m venv /data/venv || true
+
+# Example: ensure npm/pnpm dirs exist
+mkdir -p /data/npm /data/npm-cache /data/pnpm /data/pnpm-store
+```
+
 ## Troubleshooting
 
 ### “disconnected (1008): pairing required” / dashboard health offline


### PR DESCRIPTION
Fixes #136.

Users expect installs to persist across restarts, but Railway containers are ephemeral. Only /data persists.

This PR:
- Documents what persists and what doesn't (brew/apt won't persist)
- Configures npm/pnpm globals to land under /data by default via ENV:
  - NPM_CONFIG_PREFIX=/data/npm
  - PNPM_HOME=/data/pnpm
  - PNPM_STORE_DIR=/data/pnpm-store
  - PATH includes /data/npm/bin and /data/pnpm
- Adds python3 + python3-venv to runtime image so users can create /data/venv
- Adds optional /data/workspace/bootstrap.sh hook (best-effort) to initialize persistent prefixes/venv

Tests:
- npm test
