### PR TITLE
Fix: stop forwarding legacy CLAWDBOT_* env vars + pairing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Fix:
   - `openclaw devices list`
   - `openclaw devices approve <requestId>`
 
+If `openclaw devices list` shows no pending request IDs:
+- Make sure you’re visiting the Control UI at `/openclaw` (or your native app) and letting it attempt to connect
+- Ensure your state dir is the Railway volume (recommended): `OPENCLAW_STATE_DIR=/data/.openclaw`
+- Check `/setup/api/debug` for the active state/workspace dirs + gateway readiness
+
 ### “unauthorized: gateway token mismatch”
 
 The Control UI connects using `gateway.remote.token` and the gateway validates `gateway.auth.token`.
@@ -134,6 +139,13 @@ Checklist:
   - `OPENCLAW_WORKSPACE_DIR=/data/workspace`
 - Ensure **Public Networking** is enabled (Railway will inject `PORT`).
 - Check Railway logs for the wrapper error: it will show `Gateway not ready:` with the reason.
+
+### Legacy CLAWDBOT_* env vars / multiple state directories
+
+If you see warnings about deprecated `CLAWDBOT_*` variables or state dir split-brain (e.g. `~/.openclaw` vs `/data/...`):
+- Use `OPENCLAW_*` variables only
+- Ensure `OPENCLAW_STATE_DIR=/data/.openclaw` and `OPENCLAW_WORKSPACE_DIR=/data/workspace`
+- Redeploy after fixing Railway Variables
 
 ### Build OOM (out of memory) on Railway
 

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,9 @@ for (const suffix of ["PUBLIC_PORT", "STATE_DIR", "WORKSPACE_DIR", "GATEWAY_TOKE
     // Best-effort compatibility shim for old Railway templates.
     // Intentionally no warning: Railway templates can still set legacy keys and warnings are noisy.
   }
+  // Avoid forwarding legacy variables into OpenClaw subprocesses.
+  // OpenClaw logs a warning when deprecated CLAWDBOT_* variables are present.
+  delete process.env[oldKey];
 }
 
 // Railway injects PORT at runtime and routes traffic to that port.


### PR DESCRIPTION
Fixes #140 and #141.

- Stop forwarding deprecated CLAWDBOT_* variables into OpenClaw subprocesses (avoids doctor warnings about ignored legacy env vars).
- Clarify pairing troubleshooting when 1008 occurs but `devices list` shows no pending requests.

Tests:
- npm test
