### PR TITLE
Fix 1008 token_missing on Railway: inject gateway token in proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Fix:
 
 If `openclaw devices list` shows no pending request IDs:
 - Make sure you’re visiting the Control UI at `/openclaw` (or your native app) and letting it attempt to connect
+  - Note: the Railway wrapper now proxies the gateway and injects the auth token automatically, so you should not need to paste the gateway token into the Control UI when using `/openclaw`.
 - Ensure your state dir is the Railway volume (recommended): `OPENCLAW_STATE_DIR=/data/.openclaw`
 - Check `/setup/api/debug` for the active state/workspace dirs + gateway readiness
 

--- a/src/server.js
+++ b/src/server.js
@@ -1328,6 +1328,16 @@ proxy.on("error", (err, _req, res) => {
   }
 });
 
+function attachGatewayAuthHeader(req) {
+  // When running behind the Railway wrapper, the gateway is only reachable from this container.
+  // The Control UI running in the browser cannot set custom Authorization headers for WebSocket
+  // connections, so we terminate auth at the wrapper by injecting the token into proxied
+  // requests.
+  if (!req?.headers?.authorization && OPENCLAW_GATEWAY_TOKEN) {
+    req.headers.authorization = `Bearer ${OPENCLAW_GATEWAY_TOKEN}`;
+  }
+}
+
 app.use(async (req, res) => {
   // If not configured, force users to /setup for any non-setup routes.
   if (!isConfigured() && !req.path.startsWith("/setup")) {
@@ -1350,6 +1360,7 @@ app.use(async (req, res) => {
     }
   }
 
+  attachGatewayAuthHeader(req);
   return proxy.web(req, res, { target: GATEWAY_TARGET });
 });
 
@@ -1417,6 +1428,7 @@ server.on("upgrade", async (req, socket, head) => {
     socket.destroy();
     return;
   }
+  attachGatewayAuthHeader(req);
   proxy.ws(req, socket, head, { target: GATEWAY_TARGET });
 });
 


### PR DESCRIPTION
Fixes #141.

Problem:
- The OpenClaw Control UI runs in the browser and cannot add custom Authorization headers to WebSocket connections.
- On Railway, we proxy /openclaw -> gateway; without an auth token, the gateway rejects with 1008 token_missing.
- This prevents pairing requests from being created, so `openclaw devices list` shows no requestId.

Fix:
- Inject `Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>` into all proxied HTTP + WS requests at the wrapper.
- Update README pairing troubleshooting to note you shouldn't need to paste the token when using /openclaw.

Tests:
- npm test
