### PR TITLE
fix: always inject gateway Bearer token for proxied requests

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1354,8 +1354,15 @@ function requireDashboardAuth(req, res, next) {
 // The gateway is only reachable from this container. The Control UI in the browser
 // cannot set custom Authorization headers for WebSocket connections, so we inject
 // the token into proxied requests at the wrapper level.
+//
+// Always overwrite the Authorization header: requireDashboardAuth has already
+// validated any inbound Basic-auth credentials, so we replace them with the
+// Bearer token the gateway expects.  Without the overwrite, requests that
+// arrive with Basic auth (e.g. external webhook callers that must satisfy
+// requireDashboardAuth) would be forwarded to the gateway with the wrong
+// scheme and rejected with 401.
 function attachGatewayAuthHeader(req) {
-  if (!req?.headers?.authorization && OPENCLAW_GATEWAY_TOKEN) {
+  if (OPENCLAW_GATEWAY_TOKEN) {
     req.headers.authorization = `Bearer ${OPENCLAW_GATEWAY_TOKEN}`;
   }
 }


### PR DESCRIPTION
## Summary

- `attachGatewayAuthHeader` only injected the gateway Bearer token when no `Authorization` header was present
- When `SETUP_PASSWORD` is set, `requireDashboardAuth` validates Basic auth but leaves the header on the request
- The gateway then receives `Authorization: Basic ...` instead of `Bearer <token>` and rejects with 401
- This breaks all external HTTP callers (`/tools/invoke`, `/hooks/*`) that must pass dashboard auth

## Fix

Always overwrite the Authorization header with the Bearer token after dashboard auth passes. The Basic auth credentials have already been validated and aren't needed downstream.

## Test plan

- [ ] Set `SETUP_PASSWORD` on a Railway deployment
- [ ] POST to `/tools/invoke` with Basic auth header — should now reach the gateway with correct Bearer token
- [ ] POST to `/hooks/wake` with Basic auth + `x-openclaw-token` — should return 200
- [ ] Control UI (browser) should continue working as before
- [ ] WebSocket connections should continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)