### PR TITLE
feat: add Anthropic support, direct API keys, and multi-model registr…

### DIFF
--- a/src/setup-app.js
+++ b/src/setup-app.js
@@ -162,6 +162,7 @@
       customProviderId: document.getElementById('customProviderId').value,
       customProviderBaseUrl: document.getElementById('customProviderBaseUrl').value,
       customProviderApi: document.getElementById('customProviderApi').value,
+      customProviderApiKey: document.getElementById('customProviderApiKey').value,
       customProviderApiKeyEnv: document.getElementById('customProviderApiKeyEnv').value,
       customProviderModelId: document.getElementById('customProviderModelId').value
     };


### PR DESCRIPTION
Add:

Custom provider improvements:
- Add anthropic-messages API protocol option
- Support direct API key input (env var takes precedence if provided)
- Support comma-separated model IDs for registering multiple models
- Auto-register models in agents.defaults.models so /models endpoint sees them
- Update UI labels and hints for Anthropic-compatible endpoints