### PR TITLE
fix: exempt /hooks/* from requireDashboardAuth middleware

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1333,6 +1333,7 @@ proxy.on("error", (err, _req, res) => {
 // not just the /setup routes.  Healthcheck is excluded so Railway probes work.
 function requireDashboardAuth(req, res, next) {
   if (req.path === "/healthz" || req.path === "/setup/healthz") return next();
+  if (req.path.startsWith("/hooks")) return next(); // allow OpenClaw webhook endpoints to bypass dashboard auth
   if (!SETUP_PASSWORD) return next(); // no password configured → open
   const header = req.headers.authorization || "";
   const [scheme, encoded] = header.split(" ");


### PR DESCRIPTION
## Problem

The `requireDashboardAuth` middleware added in #150 blocks all requests to `/hooks/*` with `SETUP_PASSWORD` Basic auth before they reach the gateway. This breaks OpenClaw's native webhook ingress for any external service (Resend, GitHub, Stripe, etc.).

See issue: #158

## Fix

Add `/hooks` to the exempt paths, so requests to `/hooks/*` pass through to the gateway directly:

```javascript
function requireDashboardAuth(req, res, next) {
  if (req.path === "/healthz" || req.path === "/setup/healthz") return next();
  if (req.path.startsWith("/hooks")) return next(); // allow OpenClaw webhook endpoints
  ...
}
```

The gateway's own `hooks.token` auth still protects these endpoints — no security regression.

## Testing

1. Enable `hooks` in `openclaw.json` with a token
2. `POST /hooks/wake` with `Authorization: Bearer <hooks-token>`
3. Should return `{"ok":true}` instead of `401 Auth required`