### PR TITLE
Fix: don't Basic-auth gate WebSocket upgrades

### DIFF
--- a/test/websocket-upgrade-auth.test.js
+++ b/test/websocket-upgrade-auth.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("ws upgrade handler does not enforce Basic auth (browsers can't send headers)", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  const idx = src.indexOf('server.on("upgrade"');
+  assert.ok(idx >= 0);
+  const window = src.slice(idx, idx + 700);
+
+  // Regression guard for issue #162: do not destroy browser websocket connections
+  // due to missing Authorization: Basic.
+  assert.doesNotMatch(window, /WebSocket password protection/);
+  assert.doesNotMatch(window, /scheme === "Basic"/);
+  assert.doesNotMatch(window, /WWW-Authenticate/);
+});


### PR DESCRIPTION
Fixes #162.

Problem:
- PR #150 added dashboard Basic auth in the HTTP server upgrade handler.
- Browsers cannot attach Authorization: Basic headers to WebSocket handshakes, so /openclaw WS gets destroyed and the Control UI disconnects with 1006.

Fix:
- Remove Basic auth checks from the WebSocket upgrade handler.
- Keep HTTP Basic auth for /setup + /openclaw routes.
- Ensure gateway Bearer token is still injected for WS via proxyReqWs.

Tests:
- Add regression guard ensuring the upgrade handler doesn't enforce Basic auth.
- npm test
