### PR TITLE
fix: bust Docker cache when OPENCLAW_GIT_REF changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /openclaw
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
 ARG OPENCLAW_GIT_REF=v2026.3.8
-RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
+RUN echo "openclaw-ref: ${OPENCLAW_GIT_REF}" && git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.
 # Apply to all extension package.json files to handle workspace protocol (workspace:*).


### PR DESCRIPTION
## Summary
- Docker caches `RUN` layers by instruction text. Changing `ARG OPENCLAW_GIT_REF` default alone doesn't invalidate the cache because the `RUN git clone ...` instruction string stays identical.
- This causes Railway deploys to silently reuse the old cached clone even after bumping the version.
- Fix: inline the ARG into the `RUN` via `echo` so the resolved instruction changes when the ref changes.

## Test plan
- [ ] Update `OPENCLAW_GIT_REF` to a new tag and deploy — verify the build clones the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)