### PR TITLE
feat: install Google Chrome in runtime image for browser tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,12 @@ RUN apt-get update \
     tini \
     python3 \
     python3-venv \
+    wget \
+    gnupg2 \
+  && wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -O /tmp/chrome.deb \
+  && dpkg -i /tmp/chrome.deb || true \
+  && apt-get install -y -f \
+  && rm /tmp/chrome.deb \
   && rm -rf /var/lib/apt/lists/*
 
 # `openclaw update` expects pnpm. Provide it in the runtime image.


### PR DESCRIPTION
## Summary
- Installs Google Chrome stable in the runtime image so the OpenClaw `browser` tool works out of the box on Railway
- No manual SSH installs needed — Chrome persists across redeploys since it's baked into the image
- Adds ~300MB to image size

## Context
Without this, users need to SSH into the Railway container and manually `apt-get install` Chrome after every redeploy, which gets wiped by teardown.

## Test plan
- [ ] Deploy to Railway
- [ ] Run `openclaw browser start` — should find Chrome at `/usr/bin/google-chrome-stable`
- [ ] Run `openclaw browser open https://example.com && openclaw browser snapshot` — should return page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)