### PR TITLE
.github/workflows/check_domain.yml

### DIFF
--- a/.github/workflows/check_domain.yml
+++ b/.github/workflows/check_domain.yml
@@ -13,7 +13,7 @@ jobs:
       - name: 检测域名并发送通知
         run: |
           # 在这里修改你要检测的域名，空格隔开
-          DOMAINS="baidu.com google.com yoursite.com"
+          DOMAINS="hj5p.h2xv7hi1jh3.com"
           REPORT="🌐 域名状态报告：%0A"
 
           for domain in $DOMAINS; do

--- a/.github/workflows/check_domain.yml
+++ b/.github/workflows/check_domain.yml
@@ -2,9 +2,9 @@ name: 域名状态定时监测
 
 on:
   schedule:
-    # 每天早上 10:00 (UTC时间 2:00) 运行一次
+    # 每天早上 10:00 (北京时间) 运行一次
     - cron: '0 2 * * *'
-  workflow_dispatch: # 允许你手动点击按钮测试
+  workflow_dispatch: 
 
 jobs:
   check:
@@ -12,19 +12,19 @@ jobs:
     steps:
       - name: 检测域名并发送通知
         run: |
-          # 在这里修改你要检测的域名，空格隔开
           DOMAINS="hj5p.h2xv7hi1jh3.com w2qe6.i98sft5js9i.com"
           REPORT="🌐 域名状态报告：%0A"
 
           for domain in $DOMAINS; do
-            status=$(curl -Is https://$domain --connect-timeout 5 | head -n 1)
+            # 使用 -k 忽略证书错误，防止因证书过期导致检测中断
+            status=$(curl -Isk https://$domain --connect-timeout 5 | head -n 1)
             if [[ $status == *"200"* || $status == *"301"* || $status == *"302"* ]]; then
               REPORT="$REPORT ✅ $domain 正常%0A"
             else
-              REPORT="$REPORT ❌ $domain 异常 (状态: $status)%0A"
+              REPORT="$REPORT ❌ $domain 异常%0A"
             fi
           done
 
-          # 发送到 Telegram
+          # 发送通知
           curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_TOKEN }}/sendMessage" \
             -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}&text=$REPORT"

--- a/.github/workflows/check_domain.yml
+++ b/.github/workflows/check_domain.yml
@@ -1,0 +1,30 @@
+name: 域名状态定时监测
+
+on:
+  schedule:
+    # 每天早上 10:00 (UTC时间 2:00) 运行一次
+    - cron: '0 2 * * *'
+  workflow_dispatch: # 允许你手动点击按钮测试
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检测域名并发送通知
+        run: |
+          # 在这里修改你要检测的域名，空格隔开
+          DOMAINS="baidu.com google.com yoursite.com"
+          REPORT="🌐 域名状态报告：%0A"
+
+          for domain in $DOMAINS; do
+            status=$(curl -Is https://$domain --connect-timeout 5 | head -n 1)
+            if [[ $status == *"200"* || $status == *"301"* || $status == *"302"* ]]; then
+              REPORT="$REPORT ✅ $domain 正常%0A"
+            else
+              REPORT="$REPORT ❌ $domain 异常 (状态: $status)%0A"
+            fi
+          done
+
+          # 发送到 Telegram
+          curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_TOKEN }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}&text=$REPORT"

--- a/.github/workflows/check_domain.yml
+++ b/.github/workflows/check_domain.yml
@@ -26,5 +26,5 @@ jobs:
           done
 
           # 关键发送步骤：请确保这里的变量名与你在 Settings 里填的一致
-          curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_TOKEN }}/sendMessage" \
+          curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_botTOKEN }}/sendMessage" \
             -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}&text=$REPORT"

--- a/.github/workflows/check_domain.yml
+++ b/.github/workflows/check_domain.yml
@@ -13,7 +13,7 @@ jobs:
       - name: 检测域名并发送通知
         run: |
           # 在这里修改你要检测的域名，空格隔开
-          DOMAINS="hj5p.h2xv7hi1jh3.com"
+          DOMAINS="hj5p.h2xv7hi1jh3.com w2qe6.i98sft5js9i.com"
           REPORT="🌐 域名状态报告：%0A"
 
           for domain in $DOMAINS; do

--- a/.github/workflows/check_domain.yml
+++ b/.github/workflows/check_domain.yml
@@ -2,8 +2,7 @@ name: 域名状态定时监测
 
 on:
   schedule:
-    # 每天早上 10:00 (北京时间) 运行一次
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * *' # 每天北京时间上午10点运行
   workflow_dispatch: 
 
 jobs:
@@ -12,11 +11,12 @@ jobs:
     steps:
       - name: 检测域名并发送通知
         run: |
-          DOMAINS="hj5p.h2xv7hi1jh3.com w2qe6.i98sft5js9i.com"
+          # 你的域名列表
+          DOMAINS="://h2xv7hi1jh3.com ://i98sft5js9i.com"
           REPORT="🌐 域名状态报告：%0A"
 
           for domain in $DOMAINS; do
-            # 使用 -k 忽略证书错误，防止因证书过期导致检测中断
+            # 使用 -k 忽略证书错误，防止干扰
             status=$(curl -Isk https://$domain --connect-timeout 5 | head -n 1)
             if [[ $status == *"200"* || $status == *"301"* || $status == *"302"* ]]; then
               REPORT="$REPORT ✅ $domain 正常%0A"
@@ -25,6 +25,6 @@ jobs:
             fi
           done
 
-          # 发送通知
+          # 关键发送步骤：请确保这里的变量名与你在 Settings 里填的一致
           curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_TOKEN }}/sendMessage" \
             -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}&text=$REPORT"

--- a/.github/workflows/check_domain.yml
+++ b/.github/workflows/check_domain.yml
@@ -26,5 +26,5 @@ jobs:
           done
 
           # 关键发送步骤：请确保这里的变量名与你在 Settings 里填的一致
-          curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_botTOKEN }}/sendMessage" \
-            -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}&text=$REPORT"
+          curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_botTOKEN(8421439049:AAEjdiegOooNuh9mCjM2vGfUd0Ex1fMyPcM) }}/sendMessage" \
+            -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID(8473419640) }}&text=$REPORT"


### PR DESCRIPTION
name: 域名状态定时监测

on:
  schedule:
    - cron: '02* * *' # 每天北京时间上午9点自动运行
  workflow_dispatch: # 允许你手动点按钮运行

jobs:
  check:
    runs-on: ubuntu-latest
    steps:
      - name: 检测并发送通知
        run: |
          # ↓↓↓ 把下面引号里的域名换成你自己的，空格隔开 ↓↓↓
          DOMAINS="hj5p.h2xv7hi1jh3.com"
          
          REPORT="🌐 域名状态报告：%0A"
          for domain in $DOMAINS; do
            status=$(curl -Is https://$domain --connect-timeout 5 | head -n 1)
            if [[ $status == *"200"* || $status == *"301"* || $status == *"302"* ]]; then
              REPORT="$REPORT ✅ $domain 正常%0A"
            else
              REPORT="$REPORT ❌ $domain 异常%0A"
            fi
          done
          curl -s -X POST "https://telegram.org{{ secrets.TELEGRAM_TOKEN }}/sendMessage" \
            -d "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}&text=$REPORT"
