### PR TITLE
feat: add Tailscale userspace-networking with SSH access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,16 @@ ENV NODE_ENV=production
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
+    curl \
     tini \
     python3 \
     python3-venv \
+  && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg \
+    | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null \
+  && curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list \
+    | tee /etc/apt/sources.list.d/tailscale.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends tailscale \
   && rm -rf /var/lib/apt/lists/*
 
 # `openclaw update` expects pnpm. Provide it in the runtime image.
@@ -77,6 +84,7 @@ RUN printf '%s\n' '#!/usr/bin/env bash' 'exec node /openclaw/dist/entry.js "$@"'
   && chmod +x /usr/local/bin/openclaw
 
 COPY src ./src
+RUN chmod +x /app/src/tailscale-entrypoint.sh
 
 # The wrapper listens on $PORT.
 # IMPORTANT: Do not set a default PORT here.
@@ -85,5 +93,5 @@ COPY src ./src
 EXPOSE 8080
 
 # Ensure PID 1 reaps zombies and forwards signals.
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["tini", "--", "/app/src/tailscale-entrypoint.sh"]
 CMD ["node", "src/server.js"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo packages **OpenClaw** for Railway with a small **/setup** web wizard s
 - Persistent state via **Railway Volume** (so config/credentials/memory survive redeploys)
 - One-click **Export backup** (so users can migrate off Railway later)
 - **Import backup** from `/setup` (advanced recovery)
+- **Optional Tailscale** — join your private tailnet by setting `TS_AUTHKEY` (see [Tailscale](#tailscale-optional))
 
 ## How it works (high level)
 
@@ -34,6 +35,8 @@ Recommended:
 
 Optional:
 - `OPENCLAW_GATEWAY_TOKEN` — if not set, the wrapper generates one (not ideal). In a template, set it using a generated secret.
+- `TS_AUTHKEY` — Tailscale reusable auth key; enables tailnet integration (see [Tailscale](#tailscale-optional)).
+- `TS_HOSTNAME` — Tailscale node name (default: `openclaw-railway`).
 
 Notes:
 - This template pins OpenClaw to a released version by default via Docker build arg `OPENCLAW_GIT_REF` (override if you want `main`).
@@ -104,6 +107,10 @@ python3 -m venv /data/venv || true
 # Example: ensure npm/pnpm dirs exist
 mkdir -p /data/npm /data/npm-cache /data/pnpm /data/pnpm-store
 ```
+
+## Tailscale (optional)
+
+Set `TS_AUTHKEY` (reusable, non-ephemeral key from https://login.tailscale.com/admin/settings/keys) to join the container to your tailnet on boot. Tailscale runs in userspace-networking mode — no `--privileged` or kernel modules required. State persists to `/data/tailscale` so the node identity survives redeploys. MagicDNS and Tailscale SSH (`tailscale ssh openclaw-railway`) are enabled automatically.
 
 ## Troubleshooting
 

--- a/src/tailscale-entrypoint.sh
+++ b/src/tailscale-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ -z "${TS_AUTHKEY:-}" ] && exec "$@"
+
+mkdir -p /data/tailscale /var/run/tailscale
+tailscaled --tun=userspace-networking --statedir=/data/tailscale --socket=/var/run/tailscale/tailscaled.sock &
+
+timeout 10 sh -c 'until [ -S /var/run/tailscale/tailscaled.sock ]; do sleep 0.1; done' \
+  || { echo "[tailscale] daemon not ready in 10s" >&2; exit 1; }
+
+tailscale up --authkey="${TS_AUTHKEY}" --hostname="${TS_HOSTNAME:-openclaw-railway}" --accept-dns --accept-routes --ssh
+
+exec "$@"


### PR DESCRIPTION
## Summary

Adds optional Tailscale integration to the Docker container using userspace-networking — no kernel modules, privileged mode, or `/dev/net/tun` required.

## What's added

- **Dockerfile**: installs Tailscale from the official Debian Bookworm apt repo in the runtime stage
- **`src/tailscale-entrypoint.sh`**: wrapper script that starts `tailscaled` in userspace-networking mode, waits for the socket, then brings up Tailscale with SSH enabled; skips cleanly when `TS_AUTHKEY` is unset
- **README**: documents the two new optional variables and usage

## New environment variables (both optional)

| Variable | Description |
|---|---|
| `TS_AUTHKEY` | Tailscale auth key — omit to skip Tailscale entirely |
| `TS_HOSTNAME` | Tailnet hostname (default: `openclaw-railway`) |

## Notes

- Persistent Tailscale state is stored in `/data/tailscale` (Railway volume)
- MagicDNS and SSH (`tailscale ssh`) are enabled when active
- Zero impact on deployments without `TS_AUTHKEY`
