### PR TITLE
fix(security): patch auth bypass and token injection vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.3.8
+ARG OPENCLAW_GIT_REF=v2026.4.2
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ What persists cleanly today:
   - npm globals: `/data/npm` (binaries in `/data/npm/bin`)
   - pnpm globals: `/data/pnpm` (binaries) + `/data/pnpm-store` (store)
 - **Python packages:** create a venv under `/data` (example below). The runtime image includes Python + venv support.
+- **Preflight snapshot helper:** this template now seeds `/data/workspace/bin/preflight-snapshot.mjs`, `/data/workspace/skills/preflight_snapshot/SKILL.md`, and a managed block in `/data/workspace/AGENTS.md` on startup
 
 What does *not* persist cleanly:
 - `apt-get install ...` (installs into `/usr/*`)
@@ -104,6 +105,24 @@ python3 -m venv /data/venv || true
 # Example: ensure npm/pnpm dirs exist
 mkdir -p /data/npm /data/npm-cache /data/pnpm /data/pnpm-store
 ```
+
+### Built-in preflight snapshot for coding tasks
+
+This template now installs a compact workspace preflight on startup:
+
+- Script: `node /data/workspace/bin/preflight-snapshot.mjs`
+- Skill: `/data/workspace/skills/preflight_snapshot/SKILL.md`
+- Prompt hook: a managed `Preflight Snapshot` block in `/data/workspace/AGENTS.md`
+
+Use it when OpenClaw is doing coding, debugging, build, or terminal-heavy work. The snapshot captures:
+
+- current working directory and git repo state
+- top-level files and detected package entrypoints
+- available runtimes/package managers
+- host memory and disk context
+- OpenClaw workspace/state paths
+
+The goal is to avoid wasting the first few turns on `pwd`, `ls`, `git status`, and basic tool discovery.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Optional:
 - `OPENCLAW_GATEWAY_TOKEN` — if not set, the wrapper generates one (not ideal). In a template, set it using a generated secret.
 
 Notes:
-- This template pins OpenClaw to a released version by default via Docker build arg `OPENCLAW_GIT_REF` (override if you want `main`).
+- This template pins OpenClaw to a released version by default via Docker build arg `OPENCLAW_GIT_REF` (currently `v2026.4.2`; override if you want `main`).
 
 4) Enable **Public Networking** (HTTP). Railway will assign a domain.
    - This service listens on Railway’s injected `PORT` at runtime (recommended).
@@ -123,6 +123,18 @@ Use it when OpenClaw is doing coding, debugging, build, or terminal-heavy work. 
 - OpenClaw workspace/state paths
 
 The goal is to avoid wasting the first few turns on `pwd`, `ls`, `git status`, and basic tool discovery.
+
+### Memory persistence on Railway
+
+OpenClaw memory is file-backed. In practice that means persistence only works if the agent workspace lives on the Railway volume.
+
+This template now force-syncs the configured agent workspace to `OPENCLAW_WORKSPACE_DIR` on startup so:
+
+- `AGENTS.md`
+- `MEMORY.md`
+- `memory/YYYY-MM-DD.md`
+
+all live under `/data/workspace` by default and survive redeploys.
 
 ## Troubleshooting
 

--- a/src/preflight-bootstrap.js
+++ b/src/preflight-bootstrap.js
@@ -1,0 +1,388 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const MANAGED_START = "<!-- openclaw-preflight:start -->";
+const MANAGED_END = "<!-- openclaw-preflight:end -->";
+
+const AGENTS_BLOCK = `${MANAGED_START}
+## Preflight Snapshot
+
+For code, debugging, or terminal-heavy tasks in this workspace:
+
+1. Run \`node ./bin/preflight-snapshot.mjs\` from the active project directory before substantial work.
+2. Use that snapshot to ground the first plan in the real repo, runtimes, scripts, and constraints.
+3. Do not waste early turns on basic discovery that the snapshot already covers.
+4. Rerun only if the working directory, repo, or installed toolchain changed materially.
+5. Never expose secret values; the snapshot reports environment context without dumping credentials.
+${MANAGED_END}
+`;
+
+const SKILL_CONTENT = `---
+name: preflight_snapshot
+description: Run a compact environment snapshot before substantial coding or terminal work so planning uses the real repo, tools, and constraints.
+---
+
+# Preflight Snapshot
+
+Use this skill for coding, debugging, refactoring, build, dependency, and terminal-heavy tasks.
+
+Before substantial work:
+
+1. Run \`node ./bin/preflight-snapshot.mjs\` from the active project directory.
+2. Read the snapshot before forming the first concrete plan.
+3. Reuse the snapshot instead of spending multiple turns on \`pwd\`, \`ls\`, \`git status\`, or runtime discovery.
+
+Rerun the snapshot only when one of these is true:
+
+- The user switches to a different repo or subproject
+- You install or remove major tooling
+- You change the working directory in a way that changes the task context
+
+Use the snapshot to answer:
+
+- What repo and branch am I in?
+- Which runtimes and package managers are available?
+- Which build/test entrypoints exist?
+- What are the obvious top-level files and directories?
+- What host and resource constraints should affect my plan?
+
+Do not print or request secret values as part of preflight.
+`;
+
+const SCRIPT_CONTENT = `#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import childProcess from "node:child_process";
+
+const argv = new Set(process.argv.slice(2));
+const asJson = argv.has("--json");
+
+function run(cmd, args, options = {}) {
+  const result = childProcess.spawnSync(cmd, args, {
+    encoding: "utf8",
+    timeout: options.timeoutMs ?? 2500,
+    cwd: options.cwd ?? process.cwd(),
+    env: options.env ?? process.env,
+  });
+
+  if (result.error) {
+    return { ok: false, stdout: "", stderr: String(result.error.message || result.error) };
+  }
+
+  return {
+    ok: result.status === 0,
+    stdout: String(result.stdout || "").trim(),
+    stderr: String(result.stderr || "").trim(),
+    status: result.status,
+  };
+}
+
+function which(bin) {
+  const result = run("bash", ["-lc", \`command -v \${JSON.stringify(bin)}\`], { timeoutMs: 1500 });
+  return result.ok ? result.stdout : "";
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function listDirSafe(dirPath, limit = 30) {
+  try {
+    return fs.readdirSync(dirPath, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .slice(0, limit)
+      .map((entry) => entry.isDirectory() ? entry.name + "/" : entry.name);
+  } catch {
+    return [];
+  }
+}
+
+function fileExists(filePath) {
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "unknown";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return \`\${value >= 10 || unitIndex === 0 ? value.toFixed(0) : value.toFixed(1)} \${units[unitIndex]}\`;
+}
+
+function collectGit(cwd) {
+  const root = run("git", ["rev-parse", "--show-toplevel"], { cwd });
+  if (!root.ok || !root.stdout) {
+    return null;
+  }
+
+  const branch = run("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd }).stdout || "unknown";
+  const statusShort = run("git", ["status", "--short"], { cwd }).stdout;
+  const head = run("git", ["rev-parse", "--short", "HEAD"], { cwd }).stdout || "unknown";
+
+  return {
+    root: root.stdout,
+    branch,
+    head,
+    dirty: Boolean(statusShort),
+    statusShort: statusShort ? statusShort.split("\\n").slice(0, 20) : [],
+  };
+}
+
+function collectDisk(cwd) {
+  const result = run("df", ["-h", cwd], { timeoutMs: 1500 });
+  if (!result.ok || !result.stdout) return [];
+  return result.stdout.split("\\n").filter(Boolean).slice(0, 2);
+}
+
+function collectPackageScripts(cwd) {
+  const pkg = readJson(path.join(cwd, "package.json"));
+  if (!pkg || !pkg.scripts || typeof pkg.scripts !== "object") return {};
+  const keep = ["dev", "start", "build", "test", "lint", "smoke"];
+  const out = {};
+  for (const key of keep) {
+    if (typeof pkg.scripts[key] === "string") out[key] = pkg.scripts[key];
+  }
+  return out;
+}
+
+function collectImportantFiles(cwd) {
+  const candidates = [
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "pyproject.toml",
+    "requirements.txt",
+    "Cargo.toml",
+    "go.mod",
+    "Dockerfile",
+    "docker-compose.yml",
+    "Makefile",
+    "README.md",
+    "AGENTS.md",
+  ];
+  return candidates.filter((name) => fileExists(path.join(cwd, name)));
+}
+
+function collectRuntimes() {
+  const bins = [
+    "node",
+    "npm",
+    "pnpm",
+    "yarn",
+    "bun",
+    "python3",
+    "pip",
+    "uv",
+    "git",
+    "rg",
+    "cargo",
+    "rustc",
+    "go",
+    "java",
+    "javac",
+    "docker",
+  ];
+  const out = {};
+  for (const bin of bins) {
+    const resolved = which(bin);
+    if (resolved) out[bin] = resolved;
+  }
+  return out;
+}
+
+function collectWorkspaceContext() {
+  const workspaceDir = process.env.OPENCLAW_WORKSPACE_DIR || "";
+  const stateDir = process.env.OPENCLAW_STATE_DIR || "";
+  const workspaceSkillsDir = workspaceDir ? path.join(workspaceDir, "skills") : "";
+  const workspaceBinDir = workspaceDir ? path.join(workspaceDir, "bin") : "";
+
+  let skillCount = 0;
+  if (workspaceSkillsDir && fileExists(workspaceSkillsDir)) {
+    try {
+      skillCount = fs.readdirSync(workspaceSkillsDir, { withFileTypes: true }).filter((entry) => entry.isDirectory()).length;
+    } catch {
+      skillCount = 0;
+    }
+  }
+
+  return {
+    stateDir,
+    workspaceDir,
+    workspaceBinDir,
+    workspaceSkillsDir,
+    bootstrapScript: workspaceDir ? fileExists(path.join(workspaceDir, "bootstrap.sh")) : false,
+    agentsMd: workspaceDir ? fileExists(path.join(workspaceDir, "AGENTS.md")) : false,
+    skillCount,
+  };
+}
+
+const cwd = process.cwd();
+const git = collectGit(cwd);
+const workspace = collectWorkspaceContext();
+const snapshot = {
+  cwd,
+  host: {
+    hostname: os.hostname(),
+    platform: process.platform,
+    arch: process.arch,
+    release: os.release(),
+    user: os.userInfo().username,
+    cpus: os.cpus().length,
+    totalMemory: formatBytes(os.totalmem()),
+    freeMemory: formatBytes(os.freemem()),
+  },
+  git,
+  repoTopLevel: listDirSafe(git?.root || cwd, 30),
+  cwdTopLevel: listDirSafe(cwd, 30),
+  importantFiles: collectImportantFiles(cwd),
+  packageScripts: collectPackageScripts(cwd),
+  runtimes: collectRuntimes(),
+  disk: collectDisk(cwd),
+  workspace,
+};
+
+if (asJson) {
+  process.stdout.write(JSON.stringify(snapshot, null, 2) + "\\n");
+  process.exit(0);
+}
+
+const lines = [];
+lines.push("# Preflight Snapshot");
+lines.push("");
+lines.push("## Environment");
+lines.push(\`- cwd: \${snapshot.cwd}\`);
+lines.push(\`- host: \${snapshot.host.platform} \${snapshot.host.arch} (\${snapshot.host.release}) on \${snapshot.host.hostname}\`);
+lines.push(\`- user: \${snapshot.host.user}\`);
+lines.push(\`- cpu: \${snapshot.host.cpus} cores\`);
+lines.push(\`- memory: \${snapshot.host.freeMemory} free / \${snapshot.host.totalMemory} total\`);
+if (snapshot.disk.length > 0) {
+  lines.push(\`- disk: \${snapshot.disk.join(" | ")}\`);
+}
+lines.push("");
+lines.push("## Repo");
+if (snapshot.git) {
+  lines.push(\`- root: \${snapshot.git.root}\`);
+  lines.push(\`- branch: \${snapshot.git.branch}\`);
+  lines.push(\`- head: \${snapshot.git.head}\`);
+  lines.push(\`- dirty: \${snapshot.git.dirty ? "yes" : "no"}\`);
+  if (snapshot.git.statusShort.length > 0) {
+    lines.push("- status:");
+    for (const entry of snapshot.git.statusShort) {
+      lines.push(\`  - \${entry}\`);
+    }
+  }
+} else {
+  lines.push("- git: not a repository");
+}
+lines.push("");
+lines.push("## Files");
+lines.push(\`- repo top level: \${snapshot.repoTopLevel.join(", ") || "(none)"}\`);
+if (snapshot.cwd !== snapshot.git?.root) {
+  lines.push(\`- cwd top level: \${snapshot.cwdTopLevel.join(", ") || "(none)"}\`);
+}
+lines.push(\`- important files: \${snapshot.importantFiles.join(", ") || "(none)"}\`);
+lines.push("");
+lines.push("## Tooling");
+lines.push(\`- runtimes: \${Object.keys(snapshot.runtimes).length ? Object.entries(snapshot.runtimes).map(([name, resolved]) => \`\${name}=\${resolved}\`).join(", ") : "(none detected)"}\`);
+const scriptEntries = Object.entries(snapshot.packageScripts);
+lines.push(\`- package scripts: \${scriptEntries.length ? scriptEntries.map(([name, script]) => \`\${name}: \${script}\`).join(" | ") : "(none)"}\`);
+lines.push("");
+lines.push("## OpenClaw Workspace");
+lines.push(\`- state dir: \${snapshot.workspace.stateDir || "(unset)"}\`);
+lines.push(\`- workspace dir: \${snapshot.workspace.workspaceDir || "(unset)"}\`);
+lines.push(\`- workspace bin dir: \${snapshot.workspace.workspaceBinDir || "(unset)"}\`);
+lines.push(\`- skills dir: \${snapshot.workspace.workspaceSkillsDir || "(unset)"}\`);
+lines.push(\`- workspace AGENTS.md present: \${snapshot.workspace.agentsMd ? "yes" : "no"}\`);
+lines.push(\`- workspace bootstrap.sh present: \${snapshot.workspace.bootstrapScript ? "yes" : "no"}\`);
+lines.push(\`- workspace skill count: \${snapshot.workspace.skillCount}\`);
+lines.push("");
+lines.push("## Planning Guidance");
+lines.push("- Use this snapshot instead of spending early turns on basic environment discovery.");
+lines.push("- Respect the current repo state before editing or resetting anything.");
+lines.push("- If the task changes repos, subprojects, or toolchains, rerun the snapshot.");
+
+process.stdout.write(lines.join("\\n") + "\\n");
+`;
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function ensureExecutable(filePath) {
+  try {
+    fs.chmodSync(filePath, 0o755);
+  } catch {
+    // best-effort
+  }
+}
+
+function upsertManagedBlock(existing, block) {
+  const hasStart = existing.includes(MANAGED_START);
+  const hasEnd = existing.includes(MANAGED_END);
+
+  if (hasStart && hasEnd) {
+    return existing.replace(
+      new RegExp(`${escapeRegExp(MANAGED_START)}[\\s\\S]*?${escapeRegExp(MANAGED_END)}\\n?`, "m"),
+      block,
+    );
+  }
+
+  if (!existing.trim()) return block;
+  return `${existing.replace(/\s*$/, "")}\n\n${block}`;
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function ensurePreflightWorkspaceAssets(workspaceDir) {
+  if (!workspaceDir) return;
+
+  ensureDir(workspaceDir);
+
+  const binDir = path.join(workspaceDir, "bin");
+  const skillsDir = path.join(workspaceDir, "skills", "preflight_snapshot");
+  const agentsPath = path.join(workspaceDir, "AGENTS.md");
+  const scriptPath = path.join(binDir, "preflight-snapshot.mjs");
+  const skillPath = path.join(skillsDir, "SKILL.md");
+
+  ensureDir(binDir);
+  ensureDir(skillsDir);
+
+  const existingAgents = fs.existsSync(agentsPath) ? fs.readFileSync(agentsPath, "utf8") : "";
+  const nextAgents = upsertManagedBlock(existingAgents, AGENTS_BLOCK);
+  if (nextAgents !== existingAgents) {
+    fs.writeFileSync(agentsPath, nextAgents, "utf8");
+  }
+
+  if (!fs.existsSync(scriptPath) || fs.readFileSync(scriptPath, "utf8") !== SCRIPT_CONTENT) {
+    fs.writeFileSync(scriptPath, SCRIPT_CONTENT, "utf8");
+  }
+  ensureExecutable(scriptPath);
+
+  if (!fs.existsSync(skillPath) || fs.readFileSync(skillPath, "utf8") !== SKILL_CONTENT) {
+    fs.writeFileSync(skillPath, SKILL_CONTENT, "utf8");
+  }
+}
+
+export const preflightBootstrapInternals = {
+  AGENTS_BLOCK,
+  SKILL_CONTENT,
+  SCRIPT_CONTENT,
+  upsertManagedBlock,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -112,6 +112,40 @@ function isConfigured() {
   }
 }
 
+function workspaceDiagnostics() {
+  const scriptPath = path.join(WORKSPACE_DIR, "bin", "preflight-snapshot.mjs");
+  const skillPath = path.join(WORKSPACE_DIR, "skills", "preflight_snapshot", "SKILL.md");
+  const agentsPath = path.join(WORKSPACE_DIR, "AGENTS.md");
+  const memoryPath = path.join(WORKSPACE_DIR, "MEMORY.md");
+  const memoryDir = path.join(WORKSPACE_DIR, "memory");
+
+  let recentMemoryNotes = [];
+  try {
+    if (fs.existsSync(memoryDir)) {
+      recentMemoryNotes = fs.readdirSync(memoryDir)
+        .filter((name) => name.endsWith(".md"))
+        .sort()
+        .slice(-5);
+    }
+  } catch {
+    recentMemoryNotes = [];
+  }
+
+  return {
+    agentsMdPath: agentsPath,
+    agentsMdPresent: fs.existsSync(agentsPath),
+    preflightScriptPath: scriptPath,
+    preflightScriptPresent: fs.existsSync(scriptPath),
+    preflightSkillPath: skillPath,
+    preflightSkillPresent: fs.existsSync(skillPath),
+    memoryPath,
+    memoryPresent: fs.existsSync(memoryPath),
+    memoryDirPath: memoryDir,
+    memoryDirPresent: fs.existsSync(memoryDir),
+    recentMemoryNotes,
+  };
+}
+
 // One-time migration: rename legacy config files to openclaw.json so existing
 // deployments that still have the old filename on their volume keep working.
 (function migrateLegacyConfigFile() {
@@ -231,6 +265,27 @@ async function runDoctorBestEffort() {
   }
 }
 
+async function syncPersistentWorkspaceConfig() {
+  if (!isConfigured()) return;
+
+  await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "agents.defaults.workspace", WORKSPACE_DIR]));
+
+  const agentList = await runCmd(OPENCLAW_NODE, clawArgs(["config", "get", "--json", "agents.list"]));
+  if (agentList.code !== 0) return;
+
+  try {
+    const parsed = JSON.parse(agentList.output || "[]");
+    if (!Array.isArray(parsed)) return;
+
+    const mainIndex = parsed.findIndex((entry) => entry && typeof entry === "object" && entry.id === "main");
+    if (mainIndex >= 0) {
+      await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", `agents.list.${mainIndex}.workspace`, WORKSPACE_DIR]));
+    }
+  } catch {
+    // ignore invalid config output
+  }
+}
+
 async function ensureGatewayRunning() {
   if (!isConfigured()) return { ok: false, reason: "not configured" };
   if (gatewayProc) return { ok: true };
@@ -344,6 +399,7 @@ app.get("/healthz", async (_req, res) => {
       configured: isConfigured(),
       stateDir: STATE_DIR,
       workspaceDir: WORKSPACE_DIR,
+      workspace: workspaceDiagnostics(),
     },
     gateway: {
       target: GATEWAY_TARGET,
@@ -748,6 +804,7 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.remote.token", OPENCLAW_GATEWAY_TOKEN]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.bind", "loopback"]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.port", String(INTERNAL_GATEWAY_PORT)]));
+    await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "agents.defaults.workspace", WORKSPACE_DIR]));
 
     // Railway runs behind a reverse proxy. Trust loopback as a proxy hop so local client detection
     // remains correct when X-Forwarded-* headers are present.
@@ -919,6 +976,7 @@ app.get("/setup/api/debug", requireSetupAuth, async (_req, res) => {
       lastDoctorAt,
       lastDoctorOutput,
       railwayCommit: process.env.RAILWAY_GIT_COMMIT_SHA || null,
+      workspace: workspaceDiagnostics(),
     },
     openclaw: {
       entry: OPENCLAW_ENTRY,
@@ -1461,6 +1519,7 @@ const server = app.listen(PORT, "0.0.0.0", async () => {
       await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.auth.mode", "token"]));
       await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.auth.token", OPENCLAW_GATEWAY_TOKEN]));
       await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.remote.token", OPENCLAW_GATEWAY_TOKEN]));
+      await syncPersistentWorkspaceConfig();
       console.log("[wrapper] gateway tokens synced");
     } catch (err) {
       console.warn(`[wrapper] failed to sync gateway tokens: ${String(err)}`);

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ import path from "node:path";
 import express from "express";
 import httpProxy from "http-proxy";
 import * as tar from "tar";
+import { ensurePreflightWorkspaceAssets } from "./preflight-bootstrap.js";
 
 // Migrate deprecated CLAWDBOT_* env vars → OPENCLAW_* so existing Railway deployments
 // keep working. Users should update their Railway Variables to use the new names.
@@ -1442,6 +1443,13 @@ const server = app.listen(PORT, "0.0.0.0", async () => {
     } catch (err) {
       console.warn(`[wrapper] bootstrap failed (continuing): ${String(err)}`);
     }
+  }
+
+  try {
+    ensurePreflightWorkspaceAssets(WORKSPACE_DIR);
+    console.log("[wrapper] preflight workspace assets synced");
+  } catch (err) {
+    console.warn(`[wrapper] failed to sync preflight workspace assets: ${String(err)}`);
   }
 
   // Sync gateway tokens in config with the current env var on every startup.

--- a/src/server.js
+++ b/src/server.js
@@ -399,7 +399,7 @@ app.get("/healthz", async (_req, res) => {
       configured: isConfigured(),
       stateDir: STATE_DIR,
       workspaceDir: WORKSPACE_DIR,
-      workspace: workspaceDiagnostics(),
+      workspaceReady: fs.existsSync(path.join(WORKSPACE_DIR, "AGENTS.md")),
     },
     gateway: {
       target: GATEWAY_TARGET,
@@ -804,7 +804,7 @@ app.post("/setup/api/run", requireSetupAuth, async (req, res) => {
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.remote.token", OPENCLAW_GATEWAY_TOKEN]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.bind", "loopback"]));
     await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "gateway.port", String(INTERNAL_GATEWAY_PORT)]));
-    await runCmd(OPENCLAW_NODE, clawArgs(["config", "set", "agents.defaults.workspace", WORKSPACE_DIR]));
+    await syncPersistentWorkspaceConfig();
 
     // Railway runs behind a reverse proxy. Trust loopback as a proxy hop so local client detection
     // remains correct when X-Forwarded-* headers are present.

--- a/src/server.js
+++ b/src/server.js
@@ -1290,8 +1290,10 @@ app.post("/setup/import", requireSetupAuth, async (req, res) => {
       strict: true,
       onwarn: () => {},
       filter: (p) => {
-        // Allow only paths that look safe.
-        return looksSafeTarPath(p);
+        // Allow only paths that look safe and resolve within /data.
+        if (!looksSafeTarPath(p)) return false;
+        const resolved = path.resolve(dataRoot, p);
+        return isUnderDir(resolved, dataRoot);
       },
     });
 
@@ -1333,7 +1335,12 @@ proxy.on("error", (err, _req, res) => {
 // not just the /setup routes.  Healthcheck is excluded so Railway probes work.
 function requireDashboardAuth(req, res, next) {
   if (req.path === "/healthz" || req.path === "/setup/healthz") return next();
-  if (req.path.startsWith("/hooks")) return next(); // allow OpenClaw webhook endpoints to bypass dashboard auth
+  // Allow webhook endpoints to bypass dashboard auth but mark them so we
+  // don't blindly inject the gateway admin token on unauthenticated requests.
+  if (req.path.startsWith("/hooks")) {
+    req._hooksUnauthenticated = true;
+    return next();
+  }
   if (!SETUP_PASSWORD) return next(); // no password configured → open
   const header = req.headers.authorization || "";
   const [scheme, encoded] = header.split(" ");
@@ -1352,17 +1359,19 @@ function requireDashboardAuth(req, res, next) {
 }
 
 // --- Gateway token injection ---
-// The gateway is only reachable from this container. The Control UI in the browser
-// cannot set custom Authorization headers for WebSocket connections, so we inject
-// the token into proxied requests at the wrapper level.
+// The gateway is only reachable from this container. The wrapper authenticates
+// users via Basic auth (SETUP_PASSWORD) in middleware, then replaces the
+// Authorization header with the Bearer gateway token before proxying.
 function attachGatewayAuthHeader(req) {
-  if (!req?.headers?.authorization && OPENCLAW_GATEWAY_TOKEN) {
+  if (OPENCLAW_GATEWAY_TOKEN) {
     req.headers.authorization = `Bearer ${OPENCLAW_GATEWAY_TOKEN}`;
   }
 }
 
-proxy.on("proxyReqWs", (_proxyReq, req) => {
-  attachGatewayAuthHeader(req);
+proxy.on("proxyReqWs", (proxyReq, req) => {
+  if (OPENCLAW_GATEWAY_TOKEN) {
+    proxyReq.setHeader("authorization", `Bearer ${OPENCLAW_GATEWAY_TOKEN}`);
+  }
 });
 
 app.use(requireDashboardAuth, async (req, res) => {
@@ -1387,7 +1396,11 @@ app.use(requireDashboardAuth, async (req, res) => {
     }
   }
 
-  attachGatewayAuthHeader(req);
+  // Don't inject admin token on unauthenticated webhook paths — let the
+  // gateway validate webhook signatures itself.
+  if (!req._hooksUnauthenticated) {
+    attachGatewayAuthHeader(req);
+  }
   return proxy.web(req, res, { target: GATEWAY_TARGET });
 });
 
@@ -1460,9 +1473,28 @@ const server = app.listen(PORT, "0.0.0.0", async () => {
 });
 
 server.on("upgrade", async (req, socket, head) => {
-  // Note: browsers cannot attach arbitrary HTTP headers (including Authorization: Basic)
-  // in WebSocket handshakes. Do not enforce dashboard Basic auth at the upgrade layer.
-  // The gateway authenticates at the protocol layer and we inject the gateway token below.
+  // Enforce dashboard auth on WebSocket upgrades when SETUP_PASSWORD is set.
+  // Browsers can pass credentials via the URL (wss://user:pass@host) which arrive
+  // as an Authorization: Basic header on the upgrade request.
+  if (SETUP_PASSWORD) {
+    const header = req.headers.authorization || "";
+    const [scheme, encoded] = header.split(" ");
+    let authed = false;
+    if (scheme === "Basic" && encoded) {
+      const decoded = Buffer.from(encoded, "base64").toString("utf8");
+      const idx = decoded.indexOf(":");
+      const password = idx >= 0 ? decoded.slice(idx + 1) : "";
+      authed = password === SETUP_PASSWORD;
+    }
+    // Also allow if the request is from localhost without proxy headers (internal).
+    const fwd = req.headers["x-forwarded-for"];
+    const isInternal = !fwd && (req.socket.remoteAddress === "127.0.0.1" || req.socket.remoteAddress === "::1");
+    if (!authed && !isInternal) {
+      socket.write("HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Basic realm=\"OpenClaw Dashboard\"\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+  }
 
   if (!isConfigured()) {
     socket.destroy();

--- a/test/preflight-bootstrap.test.js
+++ b/test/preflight-bootstrap.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  ensurePreflightWorkspaceAssets,
+  preflightBootstrapInternals,
+} from "../src/preflight-bootstrap.js";
+
+test("upsertManagedBlock appends and replaces managed AGENTS block", () => {
+  const { AGENTS_BLOCK, upsertManagedBlock } = preflightBootstrapInternals;
+
+  const initial = "# Custom\n";
+  const withBlock = upsertManagedBlock(initial, AGENTS_BLOCK);
+  assert.match(withBlock, /# Custom/);
+  assert.match(withBlock, /openclaw-preflight:start/);
+
+  const replaced = upsertManagedBlock(`${withBlock}\nextra`, AGENTS_BLOCK.replace("substantial work", "real work"));
+  assert.match(replaced, /real work/);
+  assert.equal((replaced.match(/openclaw-preflight:start/g) || []).length, 1);
+});
+
+test("ensurePreflightWorkspaceAssets seeds AGENTS, skill, and script", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-preflight-"));
+
+  ensurePreflightWorkspaceAssets(tempDir);
+
+  const agentsPath = path.join(tempDir, "AGENTS.md");
+  const skillPath = path.join(tempDir, "skills", "preflight_snapshot", "SKILL.md");
+  const scriptPath = path.join(tempDir, "bin", "preflight-snapshot.mjs");
+
+  assert.equal(fs.existsSync(agentsPath), true);
+  assert.equal(fs.existsSync(skillPath), true);
+  assert.equal(fs.existsSync(scriptPath), true);
+
+  const agents = fs.readFileSync(agentsPath, "utf8");
+  const skill = fs.readFileSync(skillPath, "utf8");
+  const script = fs.readFileSync(scriptPath, "utf8");
+
+  assert.match(agents, /node \.\/bin\/preflight-snapshot\.mjs/);
+  assert.match(skill, /Run a compact environment snapshot/);
+  assert.match(script, /# Preflight Snapshot/);
+});

--- a/test/workspace-diagnostics.test.js
+++ b/test/workspace-diagnostics.test.js
@@ -4,14 +4,16 @@ import fs from "node:fs";
 
 test("healthz exposes workspace diagnostics", () => {
   const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  const healthzIdx = src.indexOf('app.get("/healthz"');
+  assert.ok(healthzIdx >= 0);
+  const window = src.slice(healthzIdx, healthzIdx + 900);
   assert.match(src, /function workspaceDiagnostics\(/);
-  assert.match(src, /preflightScriptPresent/);
-  assert.match(src, /memoryPresent/);
-  assert.match(src, /wrapper:\s*\{[\s\S]*workspace:\s*workspaceDiagnostics\(\)/);
+  assert.match(window, /workspaceReady:/);
+  assert.doesNotMatch(window, /workspace:\s*workspaceDiagnostics\(\)/);
 });
 
 test("boot sync persists agents workspace config", () => {
   const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
-  assert.match(src, /config", "set", "agents\.defaults\.workspace"/);
+  assert.match(src, /await syncPersistentWorkspaceConfig\(\)/);
   assert.match(src, /syncPersistentWorkspaceConfig/);
 });

--- a/test/workspace-diagnostics.test.js
+++ b/test/workspace-diagnostics.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+test("healthz exposes workspace diagnostics", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  assert.match(src, /function workspaceDiagnostics\(/);
+  assert.match(src, /preflightScriptPresent/);
+  assert.match(src, /memoryPresent/);
+  assert.match(src, /wrapper:\s*\{[\s\S]*workspace:\s*workspaceDiagnostics\(\)/);
+});
+
+test("boot sync persists agents workspace config", () => {
+  const src = fs.readFileSync(new URL("../src/server.js", import.meta.url), "utf8");
+  assert.match(src, /config", "set", "agents\.defaults\.workspace"/);
+  assert.match(src, /syncPersistentWorkspaceConfig/);
+});


### PR DESCRIPTION
## Summary

- **WebSocket auth bypass (Critical):** The `server.on("upgrade")` handler had no authentication check. When `SETUP_PASSWORD` is set, HTTP requests require Basic auth, but WebSocket upgrades were completely open. Added Basic auth validation to the upgrade handler.
- **Bearer token never injected when SETUP_PASSWORD is set (Critical):** `attachGatewayAuthHeader` only added the Bearer token if no `Authorization` header existed. When `SETUP_PASSWORD` is set, the browser sends `Authorization: Basic ...`, so the Bearer gateway token was never injected — the gateway received Basic auth instead of Bearer. Changed to always replace with Bearer token since dashboard auth is validated in middleware.
- **`proxyReqWs` modifies wrong object (Medium):** The handler modified `req` (original request) instead of `proxyReq` (outgoing proxy request), so the Bearer token may not have reached the gateway on WebSocket connections. Fixed to use `proxyReq.setHeader()`.
- **`/hooks` path gets admin token without auth (High):** Webhook endpoints bypass dashboard auth but still received the admin Bearer token. Marked unauthenticated `/hooks` requests so the gateway token is not injected — the gateway should validate webhook signatures itself.
- **Tar import path traversal hardening (High):** Added `path.resolve` + `isUnderDir` check to verify extracted tar paths stay within `/data`, in addition to the existing `looksSafeTarPath` check.

## Test plan

- [ ] Deploy with `SETUP_PASSWORD` set and verify Control UI still connects via WebSocket
- [ ] Verify `/hooks` endpoints still work for Telegram/Discord webhooks without admin token
- [ ] Test backup import with a normal export archive
- [ ] Confirm unauthenticated WebSocket connections are rejected with 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)