### PR TITLE
chore: bump OPENCLAW_GIT_REF to v2026.3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.3.8
+ARG OPENCLAW_GIT_REF=v2026.3.12
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.


### PR DESCRIPTION
Bumps the pinned OpenClaw release tag from v2026.3.8 to v2026.3.12. Follows up on #182.

v2026.3.12 covers 8 additional security CVEs on top of v2026.3.11's WebSocket cross-site hijacking fix (GHSA-5wcw-8jjv-m286), including exec approval spoofing, Unicode obfuscation bypasses, shared-token scope elevation, and sandboxed subagent session boundary escapes.

Skipping v2026.3.13 (non-standard `v2026.3.13-1` tag due to a broken original release) and the v2026.4.x series, which currently has several open critical regressions (exec broken, channels failing to initialize). v2026.3.12 is 27 days old with no gateway startup issues reported and a clean standard tag.

Single-line Dockerfile change. Local `npm test` passes (12/12).