### PR TITLE
fix: proxy body forwarding and auth for /hooks routes

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1316,6 +1316,17 @@ const proxy = httpProxy.createProxyServer({
   xfwd: true,
 });
 
+// express.json() consumes the request stream before http-proxy can pipe
+// it.  Re-serialize req.body so the gateway receives the full payload.
+proxy.on("proxyReq", (proxyReq, req) => {
+  if (req.body && typeof req.body === "object" && Object.keys(req.body).length > 0) {
+    const bodyData = JSON.stringify(req.body);
+    proxyReq.setHeader("Content-Type", "application/json");
+    proxyReq.setHeader("Content-Length", Buffer.byteLength(bodyData));
+    proxyReq.write(bodyData);
+  }
+});
+
 proxy.on("error", (err, _req, res) => {
   console.error("[proxy]", err);
   try {
@@ -1387,7 +1398,11 @@ app.use(requireDashboardAuth, async (req, res) => {
     }
   }
 
-  attachGatewayAuthHeader(req);
+  // Hooks have their own auth token (hooks.token); do not inject the
+  // gateway token or the hooks handler will read the wrong credential.
+  if (!req.path.startsWith("/hooks")) {
+    attachGatewayAuthHeader(req);
+  }
   return proxy.web(req, res, { target: GATEWAY_TARGET });
 });
 


### PR DESCRIPTION
## Summary

Two issues prevented the OpenClaw hooks endpoint (`/hooks/agent`, `/hooks/wake`) from working through the Express proxy wrapper:

- **Body not forwarded**: `express.json()` consumes the request body stream before `http-proxy` can pipe it to the gateway. Added a `proxyReq` handler to re-serialize `req.body` so the gateway receives the full payload.

- **Wrong auth token injected**: `attachGatewayAuthHeader` injected the gateway token into the `Authorization` header for `/hooks` requests when no `Authorization` header was present. The hooks handler reads `Authorization` first, so it would compare the gateway token against the hooks token and reject with 401. Skipping the injection for `/hooks` routes lets the hooks-specific `X-OpenClaw-Token` header work correctly.

## Test plan

- [x] `POST /hooks/agent` with `Authorization: Bearer <hooks-token>` returns `200 { ok: true, runId: "..." }`
- [x] `POST /hooks/agent` with `X-OpenClaw-Token: <hooks-token>` returns `200 { ok: true, runId: "..." }`
- [x] `POST /hooks/wake` with body `{ "text": "..." }` returns `200 { ok: true, mode: "now" }`
- [x] Wrong token returns `401 Unauthorized`
- [x] Dashboard/Control UI still works (gateway token injection preserved for non-hooks routes)