### PR TITLE
Add workflow to bump OpenClaw version automatically

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,21 +1,19 @@
 name: Docker build
-
 on:
   pull_request:
   push:
     branches:
       - main
-
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       # Build only (no push). If this fails, the PR breaks container builds.
       - name: Build Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: Bump OpenClaw version
+
+on:
+  schedule:
+    # Runs every Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual trigger from GitHub UI
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run bump script
+        id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          output=$(node scripts/bump-openclaw-ref.mjs)
+          echo "$output"
+          if echo "$output" | grep -q "No update needed"; then
+            echo "updated=false" >> $GITHUB_OUTPUT
+          else
+            # Extract the new tag from the output line: "current=vX latest=vY"
+            new_tag=$(echo "$output" | grep -oP 'latest=\K\S+')
+            echo "updated=true" >> $GITHUB_OUTPUT
+            echo "new_tag=$new_tag" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Open PR if updated
+        if: steps.bump.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump OpenClaw to ${{ steps.bump.outputs.new_tag }}"
+          branch: "bump/openclaw-${{ steps.bump.outputs.new_tag }}"
+          delete-branch: true
+          title: "chore: bump OpenClaw to ${{ steps.bump.outputs.new_tag }}"
+          body: |
+            Automated version bump by the `bump-openclaw` workflow.
+
+            **New version:** `${{ steps.bump.outputs.new_tag }}`
+
+            Check the [OpenClaw changelog](https://github.com/openclaw/openclaw/releases/tag/${{ steps.bump.outputs.new_tag }}) for breaking changes before merging.
+          labels: dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.3.8
+ARG OPENCLAW_GIT_REF=v2026.4.14
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
+# Ignore openclaw's `packageManager` field (it pins pnpm 11); use the activated 10.23.0 instead.
+ENV COREPACK_ENABLE_PROJECT_SPEC=0
 RUN corepack enable && corepack prepare pnpm@10.23.0 --activate
 
 WORKDIR /openclaw
@@ -33,12 +35,31 @@ RUN set -eux; \
     sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
-RUN cat >> pnpm-workspace.yaml <<'EOF'
+RUN python3 - <<'PY'
+from pathlib import Path
 
-minimumReleaseAge: 0
-resolutionMode: highest
-minimumReleaseAgeIgnoreMissingTime: true
-EOF
+path = Path("pnpm-workspace.yaml")
+lines = path.read_text().splitlines()
+
+remove_keys = (
+    "minimumReleaseAge:",
+    "resolutionMode:",
+    "minimumReleaseAgeIgnoreMissingTime:",
+)
+
+cleaned = [
+    line for line in lines
+    if not line.lstrip().startswith(remove_keys)
+]
+
+path.write_text(
+    "\n".join(cleaned).rstrip()
+    + "\n\n"
+    + "minimumReleaseAge: 0\n"
+    + "resolutionMode: highest\n"
+    + "minimumReleaseAgeIgnoreMissingTime: true\n"
+)
+PY
 
 RUN pnpm install --no-frozen-lockfile
 RUN pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.4.14
+ARG OPENCLAW_GIT_REF=v2026.5.3
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.5.3
+ARG OPENCLAW_GIT_REF=v2026.5.7
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.5.3
+ARG OPENCLAW_GIT_REF=v2026.5.12
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN set -eux; \
     sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
+RUN echo "resolution-mode=highest" >> .npmrc
 RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
 ENV OPENCLAW_PREFER_PNPM=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.23.0 --activate
 
 WORKDIR /openclaw
 
@@ -33,7 +33,13 @@ RUN set -eux; \
     sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
-RUN echo "resolution-mode=highest" >> .npmrc
+RUN cat >> pnpm-workspace.yaml <<'EOF'
+
+minimumReleaseAge: 0
+resolutionMode: highest
+minimumReleaseAgeIgnoreMissingTime: true
+EOF
+
 RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
 ENV OPENCLAW_PREFER_PNPM=1


### PR DESCRIPTION
This workflow automatically bumps the OpenClaw version on a schedule or manually, checks for updates, and opens a pull request if a new version is available.