### PR TITLE
Free port 18789 before gateway spawn, fail /healthz when dead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN apt-get update \
     tini \
     python3 \
     python3-venv \
+    lsof \
+    procps \
+    psmisc \
   && rm -rf /var/lib/apt/lists/*
 
 # `openclaw update` expects pnpm. Provide it in the runtime image.

--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@
 builder = "dockerfile"
 
 [deploy]
-healthcheckPath = "/setup/healthz"
+healthcheckPath = "/healthz"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"
 

--- a/src/server.js
+++ b/src/server.js
@@ -143,6 +143,53 @@ let lastGatewayExit = null;
 let lastDoctorOutput = null;
 let lastDoctorAt = null;
 
+async function tryFreePort(port, { signal = 'SIGTERM', waitMs = 500 } = {}) {
+  // On container restart/restart cycles, a zombie openclaw process can keep
+  // port 18789 bound. The supervisor's own tracked handle is null (we're fresh)
+  // so childProcess.kill can't reach it. Shell out to lsof/fuser (installed in
+  // the Dockerfile runtime stage) to find the PID and send it a signal so the
+  // next spawn doesn't fail with EADDRINUSE.
+  const { execFile } = childProcess;
+  const tryCmd = (cmd, args) => new Promise((resolve) => {
+    execFile(cmd, args, { timeout: 3000 }, (err, stdout) => {
+      resolve({ err, stdout: (stdout || '').toString().trim() });
+    });
+  });
+
+  // Prefer lsof: returns one PID per line with -t.
+  let pids = [];
+  const lsof = await tryCmd('lsof', ['-t', `-i:${port}`, '-sTCP:LISTEN']);
+  if (!lsof.err && lsof.stdout) {
+    pids = lsof.stdout.split(/\s+/).filter(Boolean);
+  }
+
+  // Fall back to fuser if lsof is missing.
+  if (pids.length === 0) {
+    const fuser = await tryCmd('fuser', [`${port}/tcp`]);
+    if (!fuser.err && fuser.stdout) {
+      pids = fuser.stdout.split(/\s+/).filter(Boolean);
+    }
+  }
+
+  if (pids.length === 0) return { killed: [], reason: 'no listener' };
+
+  const killed = [];
+  for (const raw of pids) {
+    const pid = Number.parseInt(raw, 10);
+    if (!Number.isFinite(pid) || pid <= 1) continue;
+    try {
+      process.kill(pid, signal);
+      killed.push(pid);
+    } catch {
+      // already gone
+    }
+  }
+  if (killed.length > 0 && waitMs > 0) {
+    await new Promise((r) => setTimeout(r, waitMs));
+  }
+  return { killed, reason: killed.length ? `killed with ${signal}` : 'no pids killed' };
+}
+
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
@@ -190,6 +237,24 @@ async function startGateway() {
     "--token",
     OPENCLAW_GATEWAY_TOKEN,
   ];
+
+  // Defend against zombie openclaw processes from a previous container life
+  // that never got reaped — their listener still holds INTERNAL_GATEWAY_PORT
+  // and the new spawn would fail with EADDRINUSE. lsof is installed in the
+  // runtime image for exactly this purpose.
+  try {
+    const free = await tryFreePort(INTERNAL_GATEWAY_PORT, { signal: 'SIGTERM' });
+    if (free.killed.length > 0) {
+      console.warn(`[gateway] freed port ${INTERNAL_GATEWAY_PORT} before spawn (pids=${free.killed.join(',')})`);
+      // If SIGTERM didn't stick, escalate.
+      const still = await tryFreePort(INTERNAL_GATEWAY_PORT, { signal: 'SIGKILL' });
+      if (still.killed.length > 0) {
+        console.warn(`[gateway] escalated to SIGKILL on port ${INTERNAL_GATEWAY_PORT} (pids=${still.killed.join(',')})`);
+      }
+    }
+  } catch (err) {
+    console.warn(`[gateway] tryFreePort failed: ${String(err)}`);
+  }
 
   gatewayProc = childProcess.spawn(OPENCLAW_NODE, clawArgs(args), {
     stdio: "inherit",
@@ -268,6 +333,16 @@ async function restartGateway() {
     await sleep(750);
     gatewayProc = null;
   }
+  // Always sweep port 18789 before restart — a stuck child could have escaped
+  // SIGTERM, and a previous container life may have left a zombie.
+  try {
+    const free = await tryFreePort(INTERNAL_GATEWAY_PORT, { signal: 'SIGKILL' });
+    if (free.killed.length > 0) {
+      console.warn(`[gateway] restart killed lingering pids on ${INTERNAL_GATEWAY_PORT}: ${free.killed.join(',')}`);
+    }
+  } catch {
+    // best-effort
+  }
   return ensureGatewayRunning();
 }
 
@@ -329,7 +404,8 @@ async function probeGateway() {
 // Keep this free of secrets.
 app.get("/healthz", async (_req, res) => {
   let gatewayReachable = false;
-  if (isConfigured()) {
+  const configured = isConfigured();
+  if (configured) {
     try {
       gatewayReachable = await probeGateway();
     } catch {
@@ -337,10 +413,14 @@ app.get("/healthz", async (_req, res) => {
     }
   }
 
-  res.json({
-    ok: true,
+  // Fail the healthcheck when the gateway is supposed to be running but the
+  // internal port is dead. Railway's healthcheck (restartPolicyType=on_failure)
+  // will restart the container, which clears zombie listeners.
+  const ok = !configured || gatewayReachable;
+  const body = {
+    ok,
     wrapper: {
-      configured: isConfigured(),
+      configured,
       stateDir: STATE_DIR,
       workspaceDir: WORKSPACE_DIR,
     },
@@ -351,7 +431,8 @@ app.get("/healthz", async (_req, res) => {
       lastExit: lastGatewayExit,
       lastDoctorAt,
     },
-  });
+  };
+  res.status(ok ? 200 : 503).json(body);
 });
 
 app.get("/setup/app.js", requireSetupAuth, (_req, res) => {


### PR DESCRIPTION
## Summary
- When the embedded openclaw gateway hits its 10 min run timeout (or otherwise dies unexpectedly), the wrapper's `gatewayProc` handle is lost but the OS-level listener on port 18789 stays held by a zombie. The next `gateway run` spawn fails with `EADDRINUSE`, but the wrapper process keeps running — so the container stays "up", WebSocket accepts connections, and `chat.send` fires an instant empty `chat:final`. Every message looks stuck from the user's side.
- Runtime image was missing `lsof` / `procps` / `psmisc`, so openclaw's own "port in use" recovery path (which shells out to find the owning PID) had nothing to call — logs read `Port is in use but process details are unavailable (install lsof or run as an admin user)`.
- `/healthz` always returned 200, so Railway's `restartPolicyType=on_failure` never recycled the container even when the gateway was dead.

## Changes
- Dockerfile: install `lsof`, `procps`, `psmisc` in the runtime stage.
- `src/server.js`:
  - New `tryFreePort(port, { signal })` helper — probes with `lsof -t -i:PORT -sTCP:LISTEN` (falls back to `fuser`), kills any matching PIDs.
  - `startGateway()` now calls it (SIGTERM, then escalates to SIGKILL) right before `childProcess.spawn`, so zombies from a previous container life can't EADDRINUSE the new spawn.
  - `restartGateway()` calls it after the SIGTERM + 750ms grace so a stuck child that escaped SIGTERM doesn't block the next `ensureGatewayRunning()`.
  - `/healthz` returns 503 when `isConfigured()` but `probeGateway()` fails, so Railway's healthcheck can trigger a restart.
- `railway.toml`: point `healthcheckPath` at `/healthz` (the gateway-aware one) instead of `/setup/healthz` (always 200).

## Test plan
- [ ] Fresh deploy: container boots, `/healthz` returns 200 with `gateway.reachable: true`.
- [ ] Simulate zombie: exec into container, spawn a dummy listener on port 18789, call `restartGateway` via `/setup/api/console/run` — confirm the supervisor kills the dummy listener and the new gateway spawn succeeds.
- [ ] Force the embedded run timeout, wait ~30s — confirm `/healthz` flips to 503 and Railway restarts the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)