### PR TITLE
fix(proxy): make wrapper auth actually work with current openclaw Control UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,12 @@ RUN set -eux; \
     sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
-RUN pnpm install --no-frozen-lockfile
+# Disable pnpm's minimumReleaseAge gate; openclaw extensions (e.g. tokenjuice)
+# sometimes depend on packages published <24h ago which would otherwise be blocked.
+RUN pnpm install --no-frozen-lockfile --config.minimumReleaseAge=0
 RUN pnpm build
 ENV OPENCLAW_PREFER_PNPM=1
-RUN pnpm ui:install && pnpm ui:build
+RUN pnpm ui:install --config.minimumReleaseAge=0 && pnpm ui:build
 
 
 # Runtime image

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.3.8
+ARG OPENCLAW_GIT_REF=v2026.4.12
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,24 @@
+# K8s Deployment Manifests (Hetzner / Epyc cluster)
+
+Synced from live deployment on 2026-07-18.
+
+## Files
+
+- `deployment.yaml` — Full K8s manifest (namespace, deployment, services, ingress)
+- `openclaw.json` — Gateway config (sanitized — secrets/redacted tokens removed)
+
+## Deploy
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+```
+
+## Live State (as of 2026-07-18)
+
+- Pod: `openclaw-64cb8966cc-ft95b` — 2/2 Running
+- OpenClaw binary: `2026.4.12`
+- Image: `localhost:32000/openclaw:latest`
+- DefenseClaw: `localhost:32000/involving-ai/defenseclaw-gateway:0.6.6-ext2`
+- Namespace: `openclaw` (created 156d ago)
+- Deployment revision: 29, generation: 32
+- Last restart: 2026-07-15T19:20:16-04:00

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,266 @@
+---
+# OpenClaw AI Agent + DefenseClaw Sidecar
+# Control UI at openclaw.0xcode.dev
+#
+# Config and data live on host at /home/nicks/.openclaw/
+# DefenseClaw sidecar monitors OpenClaw on localhost:18789, exposes API on 18970
+#
+# Deploy:
+#   kubectl apply -f openclaw-secrets.yaml
+#   kubectl apply -f openclaw-deployment.yaml
+#
+# ──────────────────────────────────────────────────
+#  NAMESPACE
+# ──────────────────────────────────────────────────
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openclaw
+---
+# ──────────────────────────────────────────────────
+#  DEPLOYMENT (OpenClaw + DefenseClaw sidecar)
+# ──────────────────────────────────────────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openclaw
+  template:
+    metadata:
+      labels:
+        app: openclaw
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostAliases:
+      - ip: "192.168.68.249"
+        hostnames:
+        - litellm.0xcode.dev
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+      - name: openclaw
+        image: localhost:32000/openclaw:latest
+        imagePullPolicy: Always
+        command: ["openclaw"]
+        args: ["gateway", "--allow-unconfigured"]
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+        ports:
+        - containerPort: 18789
+          name: gateway
+        env:
+        - name: OPENCLAW_GATEWAY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-secrets
+              key: gateway-token
+        - name: HOME
+          value: /home/node
+        - name: OPENCLAW_GATEWAY_BIND
+          value: "0.0.0.0"
+        - name: NODE_ENV
+          value: "production"
+        - name: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
+          value: "1"
+        - name: PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+          value: /usr/bin/chromium
+        envFrom:
+          - secretRef:
+              name: openclaw-secrets
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - name: openclaw-home
+          mountPath: /home/node/.openclaw
+        - name: host-src
+          mountPath: /host/src
+        - name: tmp-screenshots
+          mountPath: /tmp/test-screenshots
+        startupProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /
+            port: 18789
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /
+            port: 18789
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          failureThreshold: 5
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /
+            port: 18789
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          failureThreshold: 5
+          timeoutSeconds: 5
+      - name: defenseclaw
+        image: localhost:32000/involving-ai/defenseclaw-gateway:0.6.6-ext2
+        imagePullPolicy: Always
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+        ports:
+        - containerPort: 18970
+          name: defenseclaw-api
+        env:
+        - name: HOME
+          value: /home/node
+        - name: DEFENSECLAW_HOME
+          value: /home/node/.openclaw/.defenseclaw
+        - name: DEFENSECLAW_CUSTOM_PROVIDERS_PATH
+          value: /home/node/.openclaw/.defenseclaw/custom-providers.json
+        - name: DEFENSECLAW_GATEWAY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-secrets
+              key: gateway-token
+        - name: DEFENSECLAW_LLM_KEY
+          valueFrom:
+            secretKeyRef:
+              name: openclaw-secrets
+              key: DEFENSECLAW_LLM_KEY
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: "1"
+            memory: 512Mi
+        volumeMounts:
+        - name: openclaw-home
+          mountPath: /home/node/.openclaw
+        startupProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /health
+            port: 18970
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /health
+            port: 18970
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          failureThreshold: 5
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /health
+            port: 18970
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          failureThreshold: 5
+          timeoutSeconds: 5
+      volumes:
+      - name: openclaw-home
+        hostPath:
+          path: /home/nicks/.openclaw
+          type: DirectoryOrCreate
+      - name: host-src
+        hostPath:
+          path: /mnt/wdblue/src
+          type: Directory
+      - name: tmp-screenshots
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  selector:
+    app: openclaw
+  ports:
+  - port: 18789
+    targetPort: 18789
+    name: gateway
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: defenseclaw-api
+  namespace: openclaw
+spec:
+  selector:
+    app: openclaw
+  ports:
+  - port: 18970
+    targetPort: 18970
+    name: defenseclaw-api
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openclaw
+  namespace: openclaw
+spec:
+  tls:
+  - hosts:
+    - openclaw.0xcode.dev
+    secretName: wildcard-0xcode-dev-tls
+  rules:
+  - host: openclaw.0xcode.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: openclaw
+            port:
+              number: 18789
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: defenseclaw
+  namespace: openclaw
+spec:
+  ingressClassName: traefik
+  tls:
+  - hosts:
+    - defense.0xcode.dev
+    secretName: wildcard-0xcode-dev-tls
+  rules:
+  - host: defense.0xcode.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: defenseclaw-api
+            port:
+              number: 18970

--- a/k8s/openclaw.json
+++ b/k8s/openclaw.json
@@ -1,0 +1,457 @@
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "keepRecentTokens": 32768,
+        "maxHistoryShare": 0.6,
+        "mode": "default",
+        "postIndexSync": "async",
+        "recentTurnsPreserve": 6,
+        "reserveTokens": 16384
+      },
+      "imageGenerationModel": {
+        "primary": "openai/gpt-image-1"
+      },
+      "imageModel": {
+        "fallbacks": [],
+        "primary": "litellm/Qwen3.6-35B-A3B"
+      },
+      "maxConcurrent": 6,
+      "memorySearch": {
+        "local": {
+          "modelCacheDir": "/home/nicks/.openclaw/modelCacheDir"
+        },
+        "provider": "local"
+      },
+      "model": {
+        "fallbacks": [],
+        "primary": "litellm/Qwen3.6-27B-FP8"
+      },
+      "models": {
+        "litellm/Qwen3.6-27B": {
+          "params": {
+            "cacheRetention": "short"
+          }
+        },
+        "litellm/Qwen3.6-35B-A3B": {}
+      },
+      "params": {
+        "cacheRetention": "short"
+      },
+      "sandbox": {
+        "mode": "off"
+      },
+      "subagents": {
+        "archiveAfterMinutes": 60,
+        "maxConcurrent": 4,
+        "model": "litellm/Qwen3.6-35B-A3B"
+      },
+      "timeoutSeconds": 10800,
+      "workspace": "/home/nicks/.openclaw/workspace"
+    },
+    "list": [
+      {
+        "default": true,
+        "id": "general",
+        "name": "General"
+      },
+      {
+        "agentDir": "/home/nicks/.openclaw/agents/opus/agent",
+        "id": "opus",
+        "model": "anthropic/claude-opus-4-8",
+        "name": "opus",
+        "workspace": "/home/nicks/.openclaw/workspace-opus"
+      },
+      {
+        "agentDir": "/home/nicks/.openclaw/agents/qwen35b/agent",
+        "id": "qwen35b",
+        "model": "litellm/Qwen3.6-35B-A3B",
+        "name": "qwen35b",
+        "workspace": "/home/nicks/.openclaw/workspace-qwen35b"
+      }
+    ]
+  },
+  "gateway": {
+    "mode": "local",
+    "port": 18789,
+    "bind": "lan",
+    "auth": {
+      "mode": "token",
+      "token": {
+        "__COMMENT__": "redacted - use k8s secret ref"
+      }
+    },
+    "controlUi": {
+      "allowedOrigins": [
+        "https://openclaw.0xcode.dev",
+        "http://localhost:18789",
+        "http://127.0.0.1:18789"
+      ],
+      "dangerouslyDisableDeviceAuth": true
+    },
+    "http": {
+      "endpoints": {
+        "chatCompletions": {
+          "enabled": true
+        }
+      }
+    },
+    "remote": {
+      "token": {
+        "__COMMENT__": "redacted"
+      }
+    },
+    "tailscale": {
+      "mode": "off",
+      "resetOnExit": false
+    },
+    "trustedProxies": [
+      "127.0.0.0/8",
+      "10.0.0.0/8",
+      "192.168.0.0/16"
+    ]
+  },
+  "plugins": {
+    "allow": [
+      "telegram",
+      "litellm",
+      "browser",
+      "brave",
+      "memory-core",
+      "memory-wiki",
+      "openai",
+      "defenseclaw",
+      "anthropic"
+    ],
+    "entries": {
+      "anthropic": {
+        "enabled": true
+      },
+      "brave": {
+        "enabled": true,
+        "config": {
+          "webSearch": {
+            "apiKey": {
+              "__COMMENT__": "redacted"
+            }
+          }
+        }
+      },
+      "browser": {
+        "enabled": true
+      },
+      "defenseclaw": {
+        "enabled": true
+      },
+      "litellm": {
+        "enabled": true
+      },
+      "memory-core": {
+        "enabled": true,
+        "config": {
+          "dreaming": {
+            "enabled": true
+          }
+        }
+      },
+      "memory-wiki": {
+        "enabled": true
+      },
+      "openai": {
+        "enabled": true,
+        "config": {
+          "personality": "friendly"
+        }
+      },
+      "telegram": {
+        "enabled": true
+      }
+    },
+    "load": {
+      "paths": [
+        "/home/node/.openclaw/extensions/defenseclaw"
+      ]
+    }
+  },
+  "tools": {
+    "allow": [
+      "exec",
+      "process",
+      "read",
+      "write",
+      "edit",
+      "sessions_spawn"
+    ],
+    "profile": "coding",
+    "web": {
+      "fetch": {
+        "enabled": true
+      },
+      "search": {
+        "enabled": true
+      }
+    },
+    "media": {
+      "image": {
+        "enabled": true,
+        "maxBytes": 10485760,
+        "maxChars": 1000,
+        "models": [
+          {
+            "model": "Qwen3.6-27B",
+            "provider": "litellm"
+          }
+        ]
+      }
+    }
+  },
+  "mcp": {
+    "servers": {
+      "agent-memory-bridge": {
+        "command": "python3",
+        "args": [
+          "/home/node/.openclaw/mcp/agent-memory-bridge/stdio-mcp-proxy.py"
+        ]
+      }
+    }
+  },
+  "session": {
+    "dmScope": "per-channel-peer",
+    "reset": {
+      "idleMinutes": 525600,
+      "mode": "idle"
+    }
+  },
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "dmPolicy": "allowlist",
+      "groupPolicy": "allowlist",
+      "accounts": {
+        "default": {
+          "botToken": {
+            "__COMMENT__": "redacted - use k8s secret"
+          },
+          "dmPolicy": "allowlist",
+          "groupPolicy": "allowlist"
+        },
+        "opus-bot": {
+          "botToken": {
+            "__COMMENT__": "redacted"
+          },
+          "dmPolicy": "allowlist",
+          "groupPolicy": "open"
+        },
+        "qwen35b-bot": {
+          "botToken": {
+            "__COMMENT__": "redacted"
+          },
+          "dmPolicy": "allowlist",
+          "groupPolicy": "open"
+        }
+      }
+    }
+  },
+  "bindings": [
+    {
+      "agentId": "general",
+      "match": {
+        "accountId": "default",
+        "channel": "telegram"
+      }
+    },
+    {
+      "agentId": "opus",
+      "match": {
+        "accountId": "opus-bot",
+        "channel": "telegram"
+      }
+    },
+    {
+      "agentId": "qwen35b",
+      "match": {
+        "accountId": "faran_opus",
+        "channel": "telegram"
+      },
+      "type": "route"
+    },
+    {
+      "agentId": "qwen35b",
+      "match": {
+        "accountId": "qwen35b-bot",
+        "channel": "telegram"
+      },
+      "type": "route"
+    }
+  ],
+  "browser": {
+    "enabled": true,
+    "headless": true,
+    "noSandbox": true,
+    "defaultProfile": "openclaw"
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "litellm": {
+        "api": "openai-completions",
+        "apiKey": {
+          "__COMMENT__": "redacted - use k8s secret"
+        },
+        "baseUrl": "https://litellm.0xcode.dev/v1/",
+        "request": {
+          "allowPrivateNetwork": true
+        },
+        "models": [
+          {
+            "id": "Qwen3.6-27B-FP8",
+            "name": "Qwen3.6-27B-FP8 (vLLM TP=4, 5070 Ti)",
+            "contextWindow": 262144,
+            "maxTokens": 65536,
+            "reasoning": true
+          },
+          {
+            "id": "Qwen3.6-27B",
+            "name": "Qwen 3.6 27B (unified pool, 256k, vLLM TP=8)",
+            "contextWindow": 262144,
+            "maxTokens": 65536,
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ]
+          },
+          {
+            "id": "DeepSeek-V4-Flash",
+            "name": "DeepSeek V4 Flash (FP8 native, vLLM TP=8)",
+            "contextWindow": 65536,
+            "maxTokens": 65536,
+            "reasoning": true
+          },
+          {
+            "id": "MiniMax-M2.5",
+            "name": "MiniMax-M2.5",
+            "contextWindow": 196608,
+            "maxTokens": 196608,
+            "reasoning": true
+          },
+          {
+            "id": "MiniMax-M2.7",
+            "name": "MiniMax M2.7 (UD-Q8_K_XL, llama.cpp 8x 3090 + CPU spill)",
+            "contextWindow": 196608,
+            "maxTokens": 65536,
+            "reasoning": true
+          },
+          {
+            "id": "qwen3-coder-next",
+            "name": "qwen3-coder-next",
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "moonshotai/kimi-k2.5",
+            "name": "moonshotai/kimi-k2.5",
+            "contextWindow": 256000,
+            "maxTokens": 8192,
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ]
+          },
+          {
+            "id": "qwen35",
+            "name": "Qwen 3.5 397B",
+            "contextWindow": 262144,
+            "maxTokens": 81920,
+            "reasoning": true
+          },
+          {
+            "id": "user.Qwen3-Coder-Next-GGUF",
+            "name": "Qwen3 Coder Next (Local GPU)",
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "claude-opus-4-8",
+            "name": "Claude Opus 4.8",
+            "contextWindow": 200000,
+            "maxTokens": 128000,
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ]
+          },
+          {
+            "id": "Qwen3.6-35B-A3B",
+            "name": "Qwen 3.6 35B-A3B (Vision, via lemonade)",
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ]
+          }
+        ]
+      },
+      "gemma4direct": {
+        "api": "openai-completions",
+        "apiKey": "sk-no-key-required",
+        "baseUrl": "https://gemma4-26b-a4b.0xcode.dev/v1/",
+        "request": {
+          "allowPrivateNetwork": true
+        },
+        "models": [
+          {
+            "id": "user.Gemma-4-26B-A4B-GGUF",
+            "name": "Gemma 4 26B (Vision)",
+            "contextWindow": 131072,
+            "maxTokens": 32768,
+            "input": [
+              "text",
+              "image"
+            ]
+          }
+        ]
+      },
+      "minimax27direct": {
+        "api": "openai-completions",
+        "apiKey": "sk-no-key-required",
+        "baseUrl": "https://minimax-m27.0xcode.dev/v1/",
+        "request": {
+          "allowPrivateNetwork": true
+        },
+        "models": [
+          {
+            "id": "MiniMax-M2.7-UD-Q8_K_XL-00001-of-00006.gguf",
+            "name": "MiniMax M2.7 (Direct)",
+            "contextWindow": 196608,
+            "maxTokens": 65536
+          }
+        ]
+      },
+      "qwen35direct": {
+        "api": "openai-completions",
+        "apiKey": "sk-no-key-required",
+        "baseUrl": "https://qwen35-397b.0xcode.dev/v1/",
+        "request": {
+          "allowPrivateNetwork": true
+        },
+        "models": [
+          {
+            "id": "qwen35",
+            "name": "Qwen 3.5 397B (Direct)",
+            "contextWindow": 262144,
+            "maxTokens": 81920
+          }
+        ]
+      }
+    }
+  },
+  "meta": {
+    "lastTouchedAt": "2026-07-15T21:50:11.089Z",
+    "lastTouchedVersion": "2026.4.12"
+  }
+}

--- a/k8s/searxng.yaml
+++ b/k8s/searxng.yaml
@@ -116,3 +116,52 @@ metadata:
 type: Opaque
 stringData:
   secret-key: "2467017c7f4eedfb7149456be00506d9321489e07a66efc82ee67dde7637c2d4"
+---
+# ──────────────────────────────────────────────────
+#  NETWORKPOLICY (allow agents → searxng on 8080)
+# ──────────────────────────────────────────────────
+# Required because default-deny blocks all ingress in this namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agents-to-searxng
+  namespace: acme-openclaw
+spec:
+  podSelector:
+    matchLabels:
+      app: searxng
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/part-of: acme-openclaw
+    ports:
+    - port: 8080
+      protocol: TCP
+---
+# ──────────────────────────────────────────────────
+#  NETWORKPOLICY (allow agents egress → searxng)
+# ──────────────────────────────────────────────────
+# Required because allow-internet-only explicitly excludes 10.0.0.0/8
+# (the cluster pod CIDR), blocking agents from reaching internal services.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agents-egress-to-searxng
+  namespace: acme-openclaw
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: acme-openclaw
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: searxng
+    ports:
+    - port: 8080
+      protocol: TCP

--- a/k8s/searxng.yaml
+++ b/k8s/searxng.yaml
@@ -1,0 +1,118 @@
+---
+# SearXNG — Self-hosted metasearch instance
+# Deployed to Hetzner (alreadysites-us) in acme-openclaw namespace
+#
+# Deploy:
+#   kubectl --context alreadysites-us apply -f k8s/searxng.yaml
+#
+# Service DNS: searxng.acme-openclaw.svc.cluster.local:8080
+# All agents reach it via the K8s internal DNS.
+# ──────────────────────────────────────────────────
+#  NAMESPACE (if not already created)
+# ──────────────────────────────────────────────────
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acme-openclaw
+---
+# ──────────────────────────────────────────────────
+#  DEPLOYMENT
+# ──────────────────────────────────────────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: searxng
+  namespace: acme-openclaw
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: searxng
+  template:
+    metadata:
+      labels:
+        app: searxng
+    spec:
+      containers:
+      - name: searxng
+        image: searxng/searxng:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: SEARXNG_HOST
+          value: "0.0.0.0"
+        - name: SEARXNG_PORT
+          value: "8080"
+        - name: SEARXNG_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: searxng-secret
+              key: secret-key
+        resources:
+          requests:
+            cpu: 50m
+            memory: 40Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 5
+      - name: redis
+        image: redis:7-alpine
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 6379
+          name: redis
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+---
+# ──────────────────────────────────────────────────
+#  SERVICE (ClusterIP — internal only, no ingress)
+# ──────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: searxng
+  namespace: acme-openclaw
+spec:
+  selector:
+    app: searxng
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http
+---
+# ──────────────────────────────────────────────────
+#  SECRET
+# ──────────────────────────────────────────────────
+apiVersion: v1
+kind: Secret
+metadata:
+  name: searxng-secret
+  namespace: acme-openclaw
+type: Opaque
+stringData:
+  secret-key: "2467017c7f4eedfb7149456be00506d9321489e07a66efc82ee67dde7637c2d4"

--- a/k8s/searxng.yaml
+++ b/k8s/searxng.yaml
@@ -16,6 +16,22 @@ metadata:
   name: acme-openclaw
 ---
 # ──────────────────────────────────────────────────
+#  CONFIGMAP (enable JSON output format)
+# ──────────────────────────────────────────────────
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: searxng-settings
+  namespace: acme-openclaw
+data:
+  settings.yml: |
+    use_default_settings: true
+    search:
+      formats:
+        - html
+        - json
+---
+# ──────────────────────────────────────────────────
 #  DEPLOYMENT
 # ──────────────────────────────────────────────────
 apiVersion: apps/v1
@@ -52,6 +68,10 @@ spec:
             secretKeyRef:
               name: searxng-secret
               key: secret-key
+        volumeMounts:
+        - name: searxng-settings
+          mountPath: /etc/searxng/settings.yml
+          subPath: settings.yml
         resources:
           requests:
             cpu: 50m
@@ -88,6 +108,10 @@ spec:
           limits:
             cpu: 500m
             memory: 256Mi
+      volumes:
+      - name: searxng-settings
+        configMap:
+          name: searxng-settings
 ---
 # ──────────────────────────────────────────────────
 #  SERVICE (ClusterIP — internal only, no ingress)

--- a/src/server.js
+++ b/src/server.js
@@ -1338,33 +1338,133 @@ function safeEqual(a, b) {
   return crypto.timingSafeEqual(ab, bb);
 }
 
+// Cookie-based dashboard session: value = HMAC(SETUP_PASSWORD) so verification
+// is stateless, invalidates on password change, and never echoes the password.
+const DASHBOARD_COOKIE = "oc_dashboard_session";
+function dashboardSessionToken() {
+  if (!SETUP_PASSWORD) return "";
+  return crypto.createHmac("sha256", SETUP_PASSWORD).update("oc_dashboard_v1").digest("hex");
+}
+function hasValidDashboardCookie(req) {
+  if (!SETUP_PASSWORD) return false;
+  const expected = dashboardSessionToken();
+  const raw = String(req.headers.cookie || "");
+  for (const part of raw.split(";")) {
+    const [k, v] = part.trim().split("=");
+    if (k === DASHBOARD_COOKIE && v && safeEqual(v, expected)) return true;
+  }
+  return false;
+}
+
+function wantsHtml(req) {
+  return String(req.headers.accept || "").includes("text/html");
+}
+
+function renderLoginPage(message) {
+  const msg = message ? `<p class="err">${escapeHtml(message)}</p>` : "";
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>OpenClaw Dashboard</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; min-height:100vh; display:grid; place-items:center;
+         font:15px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+         background:#0b0d10; color:#e6e8eb; }
+  form { background:#13171c; padding:28px 32px; border-radius:12px;
+         box-shadow:0 10px 40px rgba(0,0,0,.4); min-width:320px; }
+  h1 { margin:0 0 16px; font-size:18px; font-weight:600; letter-spacing:.2px; }
+  label { display:block; margin:14px 0 6px; font-size:13px; color:#9aa4ae; }
+  input[type=password] { width:100%; padding:10px 12px; border-radius:8px;
+         border:1px solid #23272d; background:#0b0d10; color:inherit; font-size:14px; }
+  button { margin-top:18px; width:100%; padding:10px 12px; border-radius:8px;
+         border:0; background:#3d6bff; color:#fff; font-weight:600; cursor:pointer; }
+  button:hover { background:#4a76ff; }
+  .err { margin:0 0 10px; color:#ff6b6b; font-size:13px; }
+</style>
+</head>
+<body>
+<form method="POST" action="/__login" autocomplete="off">
+  <h1>OpenClaw Dashboard</h1>
+  ${msg}
+  <label for="p">Password</label>
+  <input id="p" type="password" name="password" autofocus required>
+  <button type="submit">Unlock</button>
+</form>
+</body>
+</html>`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+function setDashboardCookie(res) {
+  const token = dashboardSessionToken();
+  res.append(
+    "Set-Cookie",
+    `${DASHBOARD_COOKIE}=${token}; Path=/; Max-Age=2592000; HttpOnly; Secure; SameSite=Lax`,
+  );
+}
+
+// POST /__login — exchange SETUP_PASSWORD for a session cookie; browsers land
+// here from renderLoginPage. Keeps the native Basic prompt out of the UX.
+app.post(
+  "/__login",
+  express.urlencoded({ extended: false, limit: "16kb" }),
+  (req, res) => {
+    if (!SETUP_PASSWORD) return res.redirect("/");
+    const submitted = String(req.body?.password ?? "");
+    if (!safeEqual(submitted, SETUP_PASSWORD)) {
+      return res.status(401).type("html").send(renderLoginPage("Incorrect password."));
+    }
+    setDashboardCookie(res);
+    const nextPath = typeof req.query.next === "string" && req.query.next.startsWith("/") ? req.query.next : "/";
+    return res.redirect(nextPath);
+  },
+);
+
 function requireDashboardAuth(req, res, next) {
   if (req.path === "/healthz" || req.path === "/setup/healthz") return next();
   if (req.path.startsWith("/hooks")) return next(); // allow OpenClaw webhook endpoints to bypass dashboard auth
+  if (req.path === "/__login") return next();
   if (!SETUP_PASSWORD) return next(); // no password configured → open
+
+  // Cookie session: already authenticated via /__login form.
+  if (hasValidDashboardCookie(req)) return next();
+
   const header = req.headers.authorization || "";
   const [scheme, encoded] = header.split(" ");
 
   // Accept `Authorization: Bearer <GATEWAY_TOKEN>` as an equivalent credential so
   // API clients / CLIs that already hold the gateway token aren't forced through
-  // the browser Basic prompt. The Bearer header then passes through to the
-  // gateway unchanged — it's the exact credential the gateway expects.
+  // a login UI. The Bearer header passes through to the gateway unchanged.
   if (scheme === "Bearer" && encoded && OPENCLAW_GATEWAY_TOKEN && safeEqual(encoded, OPENCLAW_GATEWAY_TOKEN)) {
     return next();
   }
 
-  if (scheme !== "Basic" || !encoded) {
-    res.set("WWW-Authenticate", 'Basic realm="OpenClaw Dashboard", Bearer realm="OpenClaw Gateway"');
-    return res.status(401).send("Auth required");
+  // Accept Basic for non-browser clients (curl, scripts) that already integrated
+  // against the old behavior. On success, also set the cookie so repeat browser
+  // requests don't need to resend credentials.
+  if (scheme === "Basic" && encoded) {
+    const decoded = Buffer.from(encoded, "base64").toString("utf8");
+    const idx = decoded.indexOf(":");
+    const password = idx >= 0 ? decoded.slice(idx + 1) : "";
+    if (safeEqual(password, SETUP_PASSWORD)) {
+      setDashboardCookie(res);
+      return next();
+    }
   }
-  const decoded = Buffer.from(encoded, "base64").toString("utf8");
-  const idx = decoded.indexOf(":");
-  const password = idx >= 0 ? decoded.slice(idx + 1) : "";
-  if (password !== SETUP_PASSWORD) {
-    res.set("WWW-Authenticate", 'Basic realm="OpenClaw Dashboard", Bearer realm="OpenClaw Gateway"');
-    return res.status(401).send("Invalid password");
+
+  // Browsers: render an HTML login form instead of the native Basic dialog.
+  if (wantsHtml(req) && req.method === "GET") {
+    return res.status(401).type("html").send(renderLoginPage());
   }
-  return next();
+  // Non-browser clients still get a Basic/Bearer challenge.
+  res.set("WWW-Authenticate", 'Basic realm="OpenClaw Dashboard", Bearer realm="OpenClaw Gateway"');
+  return res.status(401).send("Auth required");
 }
 
 // --- Gateway token injection ---

--- a/src/server.js
+++ b/src/server.js
@@ -1331,21 +1331,37 @@ proxy.on("error", (err, _req, res) => {
 // --- Dashboard password protection ---
 // Require the same SETUP_PASSWORD for the entire Control UI dashboard,
 // not just the /setup routes.  Healthcheck is excluded so Railway probes work.
+function safeEqual(a, b) {
+  const ab = Buffer.from(String(a));
+  const bb = Buffer.from(String(b));
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
 function requireDashboardAuth(req, res, next) {
   if (req.path === "/healthz" || req.path === "/setup/healthz") return next();
   if (req.path.startsWith("/hooks")) return next(); // allow OpenClaw webhook endpoints to bypass dashboard auth
   if (!SETUP_PASSWORD) return next(); // no password configured → open
   const header = req.headers.authorization || "";
   const [scheme, encoded] = header.split(" ");
+
+  // Accept `Authorization: Bearer <GATEWAY_TOKEN>` as an equivalent credential so
+  // API clients / CLIs that already hold the gateway token aren't forced through
+  // the browser Basic prompt. The Bearer header then passes through to the
+  // gateway unchanged — it's the exact credential the gateway expects.
+  if (scheme === "Bearer" && encoded && OPENCLAW_GATEWAY_TOKEN && safeEqual(encoded, OPENCLAW_GATEWAY_TOKEN)) {
+    return next();
+  }
+
   if (scheme !== "Basic" || !encoded) {
-    res.set("WWW-Authenticate", 'Basic realm="OpenClaw Dashboard"');
+    res.set("WWW-Authenticate", 'Basic realm="OpenClaw Dashboard", Bearer realm="OpenClaw Gateway"');
     return res.status(401).send("Auth required");
   }
   const decoded = Buffer.from(encoded, "base64").toString("utf8");
   const idx = decoded.indexOf(":");
   const password = idx >= 0 ? decoded.slice(idx + 1) : "";
   if (password !== SETUP_PASSWORD) {
-    res.set("WWW-Authenticate", 'Basic realm="OpenClaw Dashboard"');
+    res.set("WWW-Authenticate", 'Basic realm="OpenClaw Dashboard", Bearer realm="OpenClaw Gateway"');
     return res.status(401).send("Invalid password");
   }
   return next();

--- a/src/server.js
+++ b/src/server.js
@@ -1355,10 +1355,13 @@ function requireDashboardAuth(req, res, next) {
 // The gateway is only reachable from this container. The Control UI in the browser
 // cannot set custom Authorization headers for WebSocket connections, so we inject
 // the token into proxied requests at the wrapper level.
+//
+// Must overwrite any existing Authorization header: once dashboard auth has been
+// validated, the browser's `Basic <SETUP_PASSWORD>` header would otherwise leak to
+// the gateway and be rejected as a token mismatch.
 function attachGatewayAuthHeader(req) {
-  if (!req?.headers?.authorization && OPENCLAW_GATEWAY_TOKEN) {
-    req.headers.authorization = `Bearer ${OPENCLAW_GATEWAY_TOKEN}`;
-  }
+  if (!req?.headers || !OPENCLAW_GATEWAY_TOKEN) return;
+  req.headers.authorization = `Bearer ${OPENCLAW_GATEWAY_TOKEN}`;
 }
 
 proxy.on("proxyReqWs", (_proxyReq, req) => {

--- a/src/server.js
+++ b/src/server.js
@@ -1368,10 +1368,68 @@ proxy.on("proxyReqWs", (_proxyReq, req) => {
   attachGatewayAuthHeader(req);
 });
 
+// --- Control UI bootstrap ---
+// openclaw >= v2026.4.24 changed the Control UI so the gateway token is read from
+// localStorage["openclaw.control.settings.v1"].token and sent inside the WS
+// handshake message payload, not as an HTTP Authorization header. The wrapper's
+// proxy-level Authorization injection is therefore invisible to the new auth
+// path, and the gateway replies with reason=token_missing — surfacing as a
+// second Basic auth prompt / "paste token in Control UI settings" error.
+//
+// Before the Control UI loads for the first time in a browser, serve a small
+// bootstrap HTML that writes the known gateway token into localStorage. Gated by
+// a cookie so it only runs once, and only served after requireDashboardAuth so
+// the token never leaves the authenticated dashboard trust boundary.
+const BOOTSTRAP_COOKIE = "oc_wrapper_bootstrapped";
+const CONTROL_UI_SETTINGS_KEY = "openclaw.control.settings.v1";
+
+function needsControlUiBootstrap(req) {
+  if (!OPENCLAW_GATEWAY_TOKEN) return false;
+  if (req.method !== "GET") return false;
+  if (req.path !== "/") return false;
+  const accept = String(req.headers.accept || "");
+  if (!accept.includes("text/html")) return false;
+  const cookie = String(req.headers.cookie || "");
+  return !cookie.split(";").some((c) => c.trim().startsWith(`${BOOTSTRAP_COOKIE}=`));
+}
+
+function sendControlUiBootstrap(res) {
+  const tokenJson = JSON.stringify(OPENCLAW_GATEWAY_TOKEN);
+  const keyJson = JSON.stringify(CONTROL_UI_SETTINGS_KEY);
+  // Token lands in client-side localStorage; this response is only reachable after
+  // requireDashboardAuth has validated SETUP_PASSWORD.
+  const html = `<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Loading Control UI…</title></head>
+<body>
+<script>
+(function () {
+  try {
+    var key = ${keyJson};
+    var current = {};
+    try { current = JSON.parse(localStorage.getItem(key) || "{}") || {}; } catch (_) {}
+    if (!current.token) current.token = ${tokenJson};
+    localStorage.setItem(key, JSON.stringify(current));
+  } catch (_) {}
+  document.cookie = "${BOOTSTRAP_COOKIE}=1; Path=/; Max-Age=31536000; SameSite=Strict; Secure";
+  location.replace("/");
+})();
+</script>
+</body>
+</html>
+`;
+  res.set("Cache-Control", "no-store");
+  res.status(200).type("html").send(html);
+}
+
 app.use(requireDashboardAuth, async (req, res) => {
   // If not configured, force users to /setup for any non-setup routes.
   if (!isConfigured() && !req.path.startsWith("/setup")) {
     return res.redirect("/setup");
+  }
+
+  if (isConfigured() && needsControlUiBootstrap(req)) {
+    return sendControlUiBootstrap(res);
   }
 
   if (isConfigured()) {


### PR DESCRIPTION
## Summary

Four related auth fixes that are needed together for the wrapper to work correctly with the current Control UI (openclaw >= v2026.4.24). Originally opened for the first bullet only; extended after verifying end-to-end on a live deployment surfaced the rest.

### 1. `Authorization: Bearer` always overwrites Basic before proxying

`attachGatewayAuthHeader` had a `!req?.headers?.authorization` guard. Once the browser cached Basic creds for the dashboard, every subsequent proxied request leaked `Basic <SETUP_PASSWORD>` to the gateway and was rejected as a token mismatch. Drop the guard — when `OPENCLAW_GATEWAY_TOKEN` is set, always rewrite `Authorization` to `Bearer <token>` before the proxy call. PR #164 addressed the WS path; this covers HTTP.

### 2. Bootstrap the gateway token into Control UI localStorage

openclaw **v2026.4.24** changed the Control UI auth protocol: the gateway token is now read from `localStorage["openclaw.control.settings.v1"].token` and sent inside the WS *handshake message payload*, not the HTTP Authorization header. The wrapper's proxy-level header injection is invisible to the new auth path — connect fails with `reason=token_missing` and the gateway prints "paste the token in Control UI settings".

On the first `GET /` after dashboard auth, serve a tiny bootstrap HTML that writes `GATEWAY_TOKEN` into `localStorage`, sets a 1-year `oc_wrapper_bootstrapped` cookie, and reloads. Subsequent loads go straight to the Control UI with auth already resolved client-side. Token never leaves the authenticated dashboard trust boundary.

### 3. Accept `Authorization: Bearer <GATEWAY_TOKEN>` on the wrapper itself

`requireDashboardAuth` previously only accepted Basic, so API/CLI clients already holding the gateway token were forced through the browser Basic prompt. Now accept Bearer (timing-safe compare) and advertise both schemes in `WWW-Authenticate`. Bearer passes through to the gateway unchanged.

### 4. Replace native Basic popup with a styled HTML login + session cookie

The browser's native Basic auth dialog is jarring for a production dashboard. On `GET` with `Accept: text/html` and no session, return an HTML login page. `POST /__login` validates `SETUP_PASSWORD` and sets an `HMAC(SETUP_PASSWORD)` session cookie (30-day, HttpOnly, Secure, SameSite=Lax) — stateless, invalidates automatically on password change. Basic/Bearer still accepted for curl/CLI clients; successful Basic auth also sets the cookie.

## Test plan

- [x] Existing test suite (12 tests including `websocket-upgrade-auth`) passes
- [x] Deployed live to a Railway instance — dashboard auth → Control UI → gateway WS all work without manual token paste
- [ ] `curl -H "Accept: text/html" /` returns login page (no `WWW-Authenticate: Basic` challenge)
- [ ] `curl /` (no Accept) returns `WWW-Authenticate: Basic ..., Bearer ...` (unchanged for scripts)
- [ ] `curl -H "Authorization: Bearer <GATEWAY_TOKEN>" /` succeeds
- [ ] After login, session cookie persists for 30 days; clearing site data shows login page again