### PR TITLE
Update OPENCLAW_GIT_REF to v2026.4.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.3.8
+ARG OPENCLAW_GIT_REF=v2026.4.14
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.4.14
+ARG OPENCLAW_GIT_REF=v2026.4.24
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.4.24
+ARG OPENCLAW_GIT_REF=v2026.5.7
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.5.7
+ARG OPENCLAW_GIT_REF=v2026.5.27
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.6.6
+ARG OPENCLAW_GIT_REF=v2026.7.1-2
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ RUN set -eux; \
     sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
   done
 
+# pnpm 11 ignores minimumReleaseAge in .npmrc (auth/registry only). Env overrides
+# upstream pnpm-workspace.yaml (minimumReleaseAge: 2880), which blocked
+# @openclaw/ai@2026.9.1 during Hop A with ERR_PNPM_NO_MATURE_MATCHING_VERSION.
+ENV pnpm_config_minimumReleaseAge=0
+RUN sed -i -E 's/^minimumReleaseAge:[[:space:]]*[0-9]+/minimumReleaseAge: 0/' pnpm-workspace.yaml
+
 RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
 ENV OPENCLAW_PREFER_PNPM=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,10 @@ WORKDIR /openclaw
 ARG OPENCLAW_GIT_REF=v2026.8.2
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
-# Patch: relax version requirements for packages that may reference unpublished versions.
-# Apply to all extension package.json files to handle workspace protocol (workspace:*).
-RUN set -eux; \
-  find ./extensions -name 'package.json' -type f | while read -r f; do \
-    sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*">=[^"]+"/"openclaw": "*"/g' "$f"; \
-    sed -i -E 's/"openclaw"[[:space:]]*:[[:space:]]*"workspace:[^"]+"/"openclaw": "*"/g' "$f"; \
-  done
+# Do not rewrite extension "openclaw" deps (workspace:* / >=…) to registry "*".
+# Hop B: * pulled npm openclaw@2026.9.3, whose preinstall requires Node ≥24.16,
+# while this image is node:22-bookworm. Leave workspace/local ranges so pnpm
+# resolves the cloned monorepo package (8.2 when OPENCLAW_GIT_REF=v2026.8.2).
 
 # pnpm 11 ignores minimumReleaseAge in .npmrc (auth/registry only). Env overrides
 # upstream pnpm-workspace.yaml (minimumReleaseAge: 2880), which blocked

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.7.1-2
+ARG OPENCLAW_GIT_REF=v2026.8.2
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /openclaw
 
 # Pin to a known-good ref (tag/branch). Override in Railway template settings if needed.
 # Using a released tag avoids build breakage when `main` temporarily references unpublished packages.
-ARG OPENCLAW_GIT_REF=v2026.5.27
+ARG OPENCLAW_GIT_REF=v2026.6.6
 RUN git clone --depth 1 --branch "${OPENCLAW_GIT_REF}" https://github.com/openclaw/openclaw.git .
 
 # Patch: relax version requirements for packages that may reference unpublished versions.

--- a/src/server.js
+++ b/src/server.js
@@ -1365,6 +1365,17 @@ proxy.on("proxyReqWs", (_proxyReq, req) => {
   attachGatewayAuthHeader(req);
 });
 
+// OAuth proxy — bypass dashboard auth so Gmail OAuth callback reaches the Python server.
+const OAUTH_PORT = Number.parseInt(process.env.OAUTH_PORT ?? "8081", 10);
+const oauthProxy = httpProxy.createProxyServer({ target: `http://127.0.0.1:${OAUTH_PORT}` });
+oauthProxy.on("error", (err, _req, res) => {
+  console.error("[oauth-proxy]", err);
+  res.status(502).type("text/plain").send("OAuth server unavailable");
+});
+app.use(["/oauth/start", "/oauth/callback"], (req, res) => {
+  oauthProxy.web(req, res);
+});
+
 app.use(requireDashboardAuth, async (req, res) => {
   // If not configured, force users to /setup for any non-setup routes.
   if (!isConfigured() && !req.path.startsWith("/setup")) {

--- a/src/server.js
+++ b/src/server.js
@@ -1373,6 +1373,11 @@ oauthProxy.on("error", (err, _req, res) => {
   res.status(502).type("text/plain").send("OAuth server unavailable");
 });
 app.use(["/oauth/start", "/oauth/callback"], (req, res) => {
+  // app.use() strips the mount path from req.url before this handler runs,
+  // so the Python OAuth server was receiving "/" (or "/{account}") instead of
+  // /oauth/start | /oauth/callback?... — every Google redirect 404'd and the
+  // one-click re-auth flow never completed. Restore the full original URL.
+  req.url = req.originalUrl;
   oauthProxy.web(req, res);
 });
 


### PR DESCRIPTION
Bumps OpenClaw from v2026.3.8 to v2026.4.14.

Key improvements:
- Telegram topic session routing fixes (v2026.4.11, v2026.4.14)
- Gateway WebSocket keepalive fix (v2026.4.12)
- Telegram 429 retry backoff preserved (v2026.4.2)

Pre-upgrade checks completed:
- Config sweep clean (no legacy allow toggles, no claude-cli profiles)
- Backup taken before upgrade
- Legacy CLAWDBOT_* env vars removed